### PR TITLE
[Feat] 사용자 설정(Settings) 페이지 및 기능 구현

### DIFF
--- a/hero-fe/src/api/settings.ts
+++ b/hero-fe/src/api/settings.ts
@@ -39,6 +39,7 @@ export const getDepartments = async () => {
 
 export const saveOrUpdateDepartments = async (departments: SettingsDepartmentRequestDTO[]) => {
   const response = await apiClient.post<ApiResponse<string>>(`${BASE_URL}/departments/tree`, departments);
+  console.log('saveOrUpdateDepartments API Response:', response.data);
   return response.data;
 };
 

--- a/hero-fe/src/api/settings.ts
+++ b/hero-fe/src/api/settings.ts
@@ -1,0 +1,94 @@
+import apiClient from '@/api/apiClient';
+import type {
+  SettingsDepartmentRequestDTO,
+  SettingsDepartmentResponseDTO,
+  SettingsLoginPolicyRequestDTO,
+  SettingsPermissionsRequestDTO,
+  SettingsPermissionsResponseDTO,
+  SettingsGradeRequestDTO,
+  SettingsJobTitleRequestDTO,
+  
+  Grade,
+  JobTitle,
+  Role
+} from '@/types/settings';
+
+// 공통 응답 타입 정의 (필요 시 types/api.ts 등으로 분리 권장)
+interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  message?: string;
+}
+
+interface PageResponse<T> {
+  content: T[];
+  totalPages: number;
+  totalElements: number;
+  size: number;
+  number: number;
+}
+
+const BASE_URL = '/settings';
+
+// 부서 관리
+export const getDepartments = async () => {
+  const response = await apiClient.get<ApiResponse<SettingsDepartmentResponseDTO[]>>(`${BASE_URL}/departments`);
+  console.log('getDepartments API Response:', response.data);
+  return response.data;
+};
+
+export const saveOrUpdateDepartments = async (departments: SettingsDepartmentRequestDTO[]) => {
+  const response = await apiClient.post<ApiResponse<string>>(`${BASE_URL}/departments/tree`, departments);
+  return response.data;
+};
+
+// 직급 관리
+export const getGrades = async () => {
+  const response = await apiClient.get<ApiResponse<Grade[]>>(`${BASE_URL}/grades`);
+  return response.data;
+};
+
+export const updateGrades = async (grades: any[]) => {
+  const response = await apiClient.post<ApiResponse<string>>(`${BASE_URL}/grades/batch`, grades);
+  return response.data;
+};
+
+// 직책 관리
+export const getJobTitles = async () => {
+  const response = await apiClient.get<ApiResponse<JobTitle[]>>(`${BASE_URL}/job-titles`);
+  return response.data;
+};
+
+export const updateJobTitles = async (jobTitles: any[]) => {
+  console.log('updateJobTitles API Request:', jobTitles);
+  const response = await apiClient.post<ApiResponse<string>>(`${BASE_URL}/job-titles/batch`, jobTitles);
+  return response.data;
+};
+
+// 로그인 정책
+export const getLoginPolicy = async () => {
+  const response = await apiClient.get<ApiResponse<number>>(`${BASE_URL}/login-policy`);
+  return response.data;
+};
+
+export const setLoginPolicy = async (policy: SettingsLoginPolicyRequestDTO) => {
+  const response = await apiClient.put<ApiResponse<string>>(`${BASE_URL}/login-policy`, policy);
+  return response.data;
+};
+
+// 권한 관리
+export const getPermissions = async (page: number, size: number, query?: string) => {
+  const params = { page, size, query };
+  const response = await apiClient.get<ApiResponse<PageResponse<SettingsPermissionsResponseDTO>>>(`${BASE_URL}/permissions`, { params });
+  return response.data;
+};
+
+export const getRoles = async () => {
+  const response = await apiClient.get<ApiResponse<Role[]>>(`${BASE_URL}/roles`);
+  return response.data;
+};
+
+export const updatePermissions = async (dto: SettingsPermissionsRequestDTO) => {
+  const response = await apiClient.put<ApiResponse<string>>(`${BASE_URL}/permissions`, dto);
+  return response.data;
+};

--- a/hero-fe/src/components/layout/TheSidebar.vue
+++ b/hero-fe/src/components/layout/TheSidebar.vue
@@ -528,6 +528,13 @@ const handleSubMenuClick = (key: string) => {
     router.push('/payroll/admin/policy');          // 급여 정책/설정 관리
   }
 
+  // 휴가/연차
+  else if (key === 'vacationHistory') {
+    router.push('/vacation/history');
+  } else if (key === 'vacationDept') {
+    router.push('/vacation/department');
+  }
+
   // 설정 관리 하위 메뉴 라우팅
   if(key === 'department'){
     router.push ('/settings/department');

--- a/hero-fe/src/components/layout/TheSidebar.vue
+++ b/hero-fe/src/components/layout/TheSidebar.vue
@@ -11,6 +11,7 @@
   2025/12/11 - 동근 급여 부분 추가 & JSDoc 추가
   2025/12/12 - 동근 급여 관리 부분 추가
   2025/12/14 - 동근 헤더 메인로고 클릭 시 대시보드 경로 일 때 사이드바 상태 동기화
+  2025/12/15 - 승건 설정 부분 추가, 라우팅 부분 하나의 if문으로 변경
   2025/12/16 - 민철 사이드바 스타일 높이 수정
   2025/12/16 - 동근 사이드바 관련 버그 수정(새로고침 시 active 상태 유지 & 접고 펼칠 때 active 상태 유지)
   </pre>
@@ -170,7 +171,7 @@
           </div>
         </div>
 
-          <!-- 급여 -->
+        <!-- 급여 -->
         <div
           class="menu-item has-dropdown"
           :class="{ 'active-parent': activeParent === 'payroll' }"
@@ -272,47 +273,47 @@
       </div>
     </div>
 
-        <!-- 인사 관리 -->
-        <div class="menu-item has-dropdown"
-            :class="{ 'active-parent': activeParent === 'personnel' }"
-            @click="handleParentClick('personnel')">
-          <div class="menu-content">
-            <div class="icon-wrapper">
-              <img class="personnel-icon sidebar-icon" :src="getMenuIcon('personnel')" />
-            </div>
-            <div class="menu-text">사원 관리</div>
+      <!-- 인사 관리 -->
+      <div class="menu-item has-dropdown"
+          :class="{ 'active-parent': activeParent === 'personnel' }"
+          @click="handleParentClick('personnel')">
+        <div class="menu-content">
+          <div class="icon-wrapper">
+            <img class="personnel-icon sidebar-icon" :src="getMenuIcon('personnel')" />
           </div>
-          <div class="dropdown-arrow" :class="{ rotate: isPersonnelOpen }">
-            <img class="personnel-dropdown-arrow" src="/images/dropdownArrow.png" />
-          </div>
+          <div class="menu-text">사원 관리</div>
         </div>
+        <div class="dropdown-arrow" :class="{ rotate: isPersonnelOpen }">
+          <img class="personnel-dropdown-arrow" src="/images/dropdownArrow.png" />
+        </div>
+      </div>
 
-        <div v-if="isPersonnelOpen && !isCollapsed" class="sub-menu-list">
-          <div class="sub-menu-item" :class="{ active: activeSubMenu === 'employeeList' }"
-              @click="handleSubMenuClick('employeeList')">
-            <div class="sub-menu-text">사원</div>
-          </div>
-          <div class="sub-menu-item" :class="{ active: activeSubMenu === 'turnover' }"
-              @click="handleSubMenuClick('turnover')">
-            <div class="sub-menu-text">이직률</div>
-          </div>
-          <div class="sub-menu-item" :class="{ active: activeSubMenu === 'plan' }"
-              @click="handleSubMenuClick('plan')">
-            <div class="sub-menu-text">승진 계획 등록</div>
-          </div>
-          <div class="sub-menu-item" :class="{ active: activeSubMenu === 'recommend' }"
-              @click="handleSubMenuClick('recommend')">
-            <div class="sub-menu-text">승진 추천</div>
-          </div>
-          <div class="sub-menu-item" :class="{ active: activeSubMenu === 'review' }"
-              @click="handleSubMenuClick('review')">
-            <div class="sub-menu-text">승진 심사</div>
-          </div>
-          <div class="sub-menu-item" :class="{ active: activeSubMenu === 'special' }"
-              @click="handleSubMenuClick('special')">
-            <div class="sub-menu-text">특별 승진</div>
-          </div>
+      <div v-if="isPersonnelOpen && !isCollapsed" class="sub-menu-list">
+        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'employeeList' }"
+            @click="handleSubMenuClick('employeeList')">
+          <div class="sub-menu-text">사원</div>
         </div>
+        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'turnover' }"
+            @click="handleSubMenuClick('turnover')">
+          <div class="sub-menu-text">이직률</div>
+        </div>
+        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'plan' }"
+            @click="handleSubMenuClick('plan')">
+          <div class="sub-menu-text">승진 계획 등록</div>
+        </div>
+        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'recommend' }"
+            @click="handleSubMenuClick('recommend')">
+          <div class="sub-menu-text">승진 추천</div>
+        </div>
+        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'review' }"
+            @click="handleSubMenuClick('review')">
+          <div class="sub-menu-text">승진 심사</div>
+        </div>
+        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'special' }"
+            @click="handleSubMenuClick('special')">
+          <div class="sub-menu-text">특별 승진</div>
+        </div>
+      </div>
 
         <!-- 조직도 -->
         <div class="menu-item"
@@ -325,6 +326,29 @@
             <div class="menu-text">조직도</div>
           </div>
         </div>
+
+      <!-- 설정 관리 -->
+      <div class="menu-item has-dropdown"
+          :class="{ 'active-parent': activeParent === 'settings' }"
+          @click="handleParentClick('settings')">
+        <div class="menu-content">
+          <div class="icon-wrapper">
+            <img class="settings-icon sidebar-icon" :src="getMenuIcon('settings')" />
+          </div>
+          <div class="menu-text">설정</div>
+        </div>
+        <div class="dropdown-arrow" :class="{ rotate: isSettingsOpen }">
+          <img class="personnel-dropdown-arrow" src="/images/dropdownArrow.png" />
+        </div>
+      </div>
+      
+      <div v-if="isSettingsOpen && !isCollapsed" class="sub-menu-list">
+        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'department' }"
+            @click="handleSubMenuClick('department')">
+          <div class="sub-menu-text">시스템 설정</div>
+        </div>
+      </div>
+
 
       </div>
 
@@ -375,6 +399,8 @@ const isAttendanceOpen = ref<boolean>(false);
 const isVacationOpen = ref<boolean>(false);
 const isPayrollOpen = ref<boolean>(false);
 const isPayrollAdminOpen = ref<boolean>(false);
+const isSettingsOpen = ref<boolean>(false);
+
 
 //Sidebar 접힘 여부
 const isCollapsed = ref<boolean>(false);
@@ -390,6 +416,7 @@ const menuIcons = {
   payroll: { default: '/images/payroll.svg', active: '/images/payroll-white.svg' },
   payrollAdmin: { default: '/images/payroll-admin.svg', active: '/images/payroll-admin-white.svg' },
   organization: { default: '/images/organization.svg', active: '/images/organization-white.svg' },
+  settings: { default: '/images/config.svg', active: '/images/config.svg' },
 };
 
 /**
@@ -427,6 +454,8 @@ const handleParentClick = (key: string) => {
   isVacationOpen.value = key === 'vacation' ? !isVacationOpen.value : false;
   isPayrollOpen.value = key === 'payroll' ? !isPayrollOpen.value : false;
   isPayrollAdminOpen.value = key === 'payrollAdmin' ? !isPayrollAdminOpen.value : false;
+  isSettingsOpen.value = key === 'settings' ? !isSettingsOpen.value : false;
+
 };
 
 /**
@@ -476,9 +505,9 @@ const handleSubMenuClick = (key: string) => {
   // 급여(사원)
   if (key === 'myPayroll') {
     router.push('/payroll');              // 내 급여
-    }else if (key === 'myPayrollHistory') {
-      router.push('/payroll/history');    // 내 급여 이력
-    }
+  }else if (key === 'myPayrollHistory') {
+    router.push('/payroll/history');    // 내 급여 이력
+  }
       
   // 급여관리(관리자)
   if (key === 'payrollAdminDash') {
@@ -499,12 +528,10 @@ const handleSubMenuClick = (key: string) => {
     router.push('/payroll/admin/policy');          // 급여 정책/설정 관리
   }
 
-  // 휴가/연차
-  if (key === 'vacationHistory') {
-    router.push('/vacation/history');
-  } else if (key === 'vacationDept') {
-    router.push('/vacation/department');
-}
+  // 설정 관리 하위 메뉴 라우팅
+  if(key === 'department'){
+    router.push ('/settings/department');
+  }
 };
 
 // 사이드바 접기/펼치기 토글
@@ -520,6 +547,7 @@ const handleCollapse = () => {
     isVacationOpen.value = false;
     isPayrollOpen.value = false;
     isPayrollAdminOpen.value = false;
+    isSettingsOpen.value = false;
   } else {
     syncActiveByRoute(route.path);
   }

--- a/hero-fe/src/router/index.ts
+++ b/hero-fe/src/router/index.ts
@@ -25,6 +25,7 @@ import electronicApprovalRoutes from './modules/electronicApproval';
 import payrollMeRoutes from './modules/payrollMe';
 import payrollAdminRoutes from "./modules/payrollAdmin";
 import evaluationRoutes from './modules/evaluation';
+import settingsRoutes from './modules/settings';
 import { setupAuthGuard } from './guard'; // guard.ts에서 setupAuthGuard 함수 임포트
 import personnelRoutes from './modules/personnel';
 import authRoutes from './modules/auth';
@@ -52,7 +53,8 @@ const routes: RouteRecordRaw[] = [
   ...payrollAdminRoutes,
   ...evaluationRoutes,
   ...personnelRoutes,
-  ...notificationRoutes
+  ...notificationRoutes,
+  ...settingsRoutes,
 ];
 
 const router = createRouter({
@@ -75,6 +77,6 @@ router.beforeEach((to, from, next) => {
 });
 
 // 라우터 인스턴스에 인증 가드 설정
-// setupAuthGuard(router);
+setupAuthGuard(router);
 
 export default router;

--- a/hero-fe/src/router/modules/settings.ts
+++ b/hero-fe/src/router/modules/settings.ts
@@ -1,0 +1,54 @@
+/*
+  <pre>
+  (File=>TypeScript) Name   : settings.ts
+  Description : 부서/직책/직급/권한 등의 설정을 위한 모듈입니다.
+
+  History
+  2025/12/15 - 승건 최초 작성
+  </pre>
+
+  @author 이승건
+  @version 1.0
+*/
+
+import type { RouteRecordRaw } from 'vue-router';
+import Settings from '@/views/settings/Settings.vue';
+import Department from '@/views/settings/Department.vue';
+import Grade from '@/views/settings/Grade.vue';
+import JobTitle from '@/views/settings/JobTitle.vue';
+import Permission from '@/views/settings/Permission.vue';
+
+const settingsRoutes: RouteRecordRaw[] = [
+  {
+    path: '/settings',
+    component: Settings,
+    children: [
+      {
+        path: '',
+        redirect: '/settings/department',
+      },
+      {
+        path: 'department',
+        name: 'DepartmentSettings',
+        component: Department,
+      },
+      {
+        path: 'grade',
+        name: 'GradeSettings',
+        component: Grade,
+      },
+      {
+        path: 'jobTitle',
+        name: 'JobTitleSettings',
+        component: JobTitle,
+      },
+      {
+        path: 'permission',
+        name: 'PermissionSettings',
+        component: Permission,
+      },
+    ],
+  },
+];
+
+export default settingsRoutes;

--- a/hero-fe/src/stores/auth.ts
+++ b/hero-fe/src/stores/auth.ts
@@ -66,8 +66,6 @@ export const useAuthStore = defineStore('auth', () => {
      */
     function login(token: string) {
         try {
-            // const decoded = jwtDecode<JwtPayload>(token);
-
             accessToken.value = token;
             user.value = jwtDecode<JwtPayload>(token);
 

--- a/hero-fe/src/stores/settings.ts
+++ b/hero-fe/src/stores/settings.ts
@@ -1,7 +1,13 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
-import { getDepartments, getGrades, getJobTitles, getRoles } from '@/api/settings';
-import type { SettingsDepartmentResponseDTO, Grade, JobTitle, Role } from '@/types/settings';
+import { 
+  getDepartments, getGrades, getJobTitles, getRoles,
+  saveOrUpdateDepartments, getPermissions, updatePermissions 
+} from '@/api/settings';
+import type { 
+  SettingsDepartmentResponseDTO, Grade, JobTitle, Role,
+  SettingsDepartmentRequestDTO, SettingsPermissionsRequestDTO 
+} from '@/types/settings';
 
 export const useSettingsStore = defineStore('settings', () => {
   // State
@@ -45,6 +51,19 @@ export const useSettingsStore = defineStore('settings', () => {
     }
   };
 
+  // API Wrapper Actions (컴포넌트에서 직접 API 호출 대신 사용)
+  const saveDepartments = async (data: SettingsDepartmentRequestDTO[]) => {
+    return await saveOrUpdateDepartments(data);
+  };
+
+  const fetchPermissions = async (page: number, size: number, query?: string) => {
+    return await getPermissions(page, size, query);
+  };
+
+  const modifyPermissions = async (dto: SettingsPermissionsRequestDTO) => {
+    return await updatePermissions(dto);
+  };
+
   const loadAllSettings = async () => {
     isLoading.value = true;
     await Promise.all([fetchDepartments(), fetchGrades(), fetchJobTitles(), fetchRoles()]);
@@ -61,6 +80,9 @@ export const useSettingsStore = defineStore('settings', () => {
     fetchGrades,
     fetchJobTitles,
     fetchRoles,
+    saveDepartments,
+    fetchPermissions,
+    modifyPermissions,
     loadAllSettings,
   };
 });

--- a/hero-fe/src/stores/settings.ts
+++ b/hero-fe/src/stores/settings.ts
@@ -1,0 +1,66 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { getDepartments, getGrades, getJobTitles, getRoles } from '@/api/settings';
+import type { SettingsDepartmentResponseDTO, Grade, JobTitle, Role } from '@/types/settings';
+
+export const useSettingsStore = defineStore('settings', () => {
+  // State
+  const departments = ref<SettingsDepartmentResponseDTO[]>([]);
+  const grades = ref<Grade[]>([]);
+  const jobTitles = ref<JobTitle[]>([]);
+  const roles = ref<Role[]>([]);
+  const isLoading = ref(false);
+
+  // Actions
+  const fetchDepartments = async () => {
+    try {
+      const res = await getDepartments();
+      console.log("fetchDepartments:", res);
+      if (res.success) {
+        departments.value = res.data;
+      }
+    } catch (error) {
+      console.error('Failed to fetch departments:', error);
+    }
+  };
+
+  const fetchGrades = async () => {
+    const res = await getGrades();
+    if (res.success) {
+      grades.value = res.data;
+    }
+  };
+
+  const fetchJobTitles = async () => {
+    const res = await getJobTitles();
+    if (res.success) {
+      jobTitles.value = res.data;
+    }
+  };
+
+  const fetchRoles = async () => {
+    const res = await getRoles();
+    if (res.success) {
+      roles.value = res.data;
+    }
+  };
+
+  const loadAllSettings = async () => {
+    isLoading.value = true;
+    await Promise.all([fetchDepartments(), fetchGrades(), fetchJobTitles(), fetchRoles()]);
+    isLoading.value = false;
+  };
+
+  return {
+    departments,
+    grades,
+    jobTitles,
+    roles,
+    isLoading,
+    fetchDepartments,
+    fetchGrades,
+    fetchJobTitles,
+    fetchRoles,
+    loadAllSettings,
+  };
+});

--- a/hero-fe/src/types/settings.ts
+++ b/hero-fe/src/types/settings.ts
@@ -49,6 +49,7 @@ export interface SettingsDepartmentResponseDTO {
 export interface SettingsPermissionsResponseDTO {
   employeeId: number;
   employeeName: string;
+  employeeNumber: string;
   department: string;
   grade: string;
   jobTitle: string;
@@ -68,5 +69,5 @@ export interface JobTitle {
 
 export interface Role {
   roleId: number;
-  roleName: string;
+  role: string;
 }

--- a/hero-fe/src/types/settings.ts
+++ b/hero-fe/src/types/settings.ts
@@ -1,0 +1,72 @@
+export interface SettingsDepartmentRequestDTO {
+  departmentId: number;
+  departmentName: string;
+  departmentPhone: string;
+  depth: number;
+  parentDepartmentId: number | null;
+  managerId: number | null;
+  children: SettingsDepartmentRequestDTO[];
+}
+
+export interface SettingsGradeRequestDTO {
+  gradeId: number;
+  gradeName: string;
+  requiredPoint: number;
+}
+
+export interface SettingsJobTitleRequestDTO {
+  jobTitleId: number;
+  jobTitleName: string;
+}
+
+export interface SettingsLoginPolicyRequestDTO {
+  value: number;
+}
+
+export interface SettingsPermissionsRequestDTO {
+  employeeId: number;
+  roleIds: number[];
+}
+
+export interface SettingsDepartmentManagerDTO {
+  employeeId: number;
+  employeeNumber: string;
+  employeeName: string;
+  jobTitle: string;
+  grade: string;
+}
+
+export interface SettingsDepartmentResponseDTO {
+  departmentId: number;
+  departmentName: string;
+  departmentPhone: string;
+  depth: number;
+  parentDepartmentId: number | null;
+  manager: SettingsDepartmentManagerDTO | null;
+  children: SettingsDepartmentResponseDTO[];
+}
+
+export interface SettingsPermissionsResponseDTO {
+  employeeId: number;
+  employeeName: string;
+  department: string;
+  grade: string;
+  jobTitle: string;
+  role: string[];
+}
+
+export interface Grade {
+  gradeId: number;
+  grade: string;
+  requiredPoint: number;
+}
+
+export interface JobTitle {
+  jobTitleId: number;
+  jobTitle: string;
+}
+
+export interface Role {
+  roleId: number;
+  roleName: string;
+}

--- a/hero-fe/src/views/settings/Department.vue
+++ b/hero-fe/src/views/settings/Department.vue
@@ -118,7 +118,6 @@
 <script setup lang="ts">
 import { ref, onMounted, watch } from 'vue';
 import { useSettingsStore } from '@/stores/settings';
-import { saveOrUpdateDepartments } from '@/api/settings';
 // 사원 검색 API (가정) - 실제 경로에 맞게 수정 필요
 import { fetchEmployees, fetchEmployeeSearchOptions } from '@/api/personnel'; 
 import type { SettingsDepartmentRequestDTO, SettingsDepartmentResponseDTO } from '@/types/settings';
@@ -140,16 +139,23 @@ const saveDepartments = async () => {
     // 스토어의 데이터를 Request DTO 형태로 변환
     const requestData = convertToRequestDTO(localDepartments.value);
     
-    const res = await saveOrUpdateDepartments(requestData);
+    const res = await settingsStore.saveDepartments(requestData);
+  
     if (res.success) {
       alert('부서 정보가 저장되었습니다.');
       await settingsStore.fetchDepartments(); // 최신 데이터 재조회
     } else {
       alert('저장 실패: ' + res.message);
     }
-  } catch (error) {
-    console.error(error);
-    alert('저장 중 오류가 발생했습니다.');
+  } catch (error: any) {
+    console.error('저장 중 에러 발생:', error);
+    if (error.response) console.log('Error Response:', error.response);
+
+    if (error.response && error.response.data && error.response.data.message) {
+      alert(`저장 실패: ${error.response.data.message}`);
+    } else {
+      alert('저장 중 오류가 발생했습니다.');
+    }
   }
 };
 

--- a/hero-fe/src/views/settings/Department.vue
+++ b/hero-fe/src/views/settings/Department.vue
@@ -1,0 +1,578 @@
+<template>
+  <div>
+    <div class="page-header">
+      <h2 class="page-title">부서 관리</h2>
+      <button @click="saveDepartments" class="btn-save">
+        변경사항 저장
+      </button>
+    </div>
+
+    <div v-if="settingsStore.isLoading" class="loading-text">
+      로딩 중...
+    </div>
+
+    <div v-else class="tree-container">
+      <div class="tree-actions">
+        <button @click="addRootDepartment" class="btn-add-root">+ 최상위 부서 추가</button>
+      </div>
+
+      <ul v-if="localDepartments && localDepartments.length > 0" class="tree-root">
+        <DepartmentTreeItem 
+          v-for="(dept, index) in localDepartments" 
+          :key="dept.departmentId" 
+          :department="dept" 
+          @add="handleAddDepartment"
+          @edit="handleEditDepartment"
+          @remove="handleRemoveDepartment(index)"
+        />
+      </ul>
+      <div v-else class="no-data">
+        등록된 부서 정보가 없습니다.
+      </div>
+    </div>
+
+    <!-- 부서 수정 모달 -->
+    <div v-if="showEditModal" class="modal-overlay" @click.self="closeEditModal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>부서 정보 수정</h3>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label>부서명</label>
+            <input v-model="editingDeptData.departmentName" type="text" class="form-input" placeholder="부서명 입력" />
+          </div>
+          <div class="form-group">
+            <label>전화번호</label>
+            <input v-model="editingDeptData.departmentPhone" type="text" class="form-input" placeholder="전화번호 입력" />
+          </div>
+          <div class="form-group">
+            <label>관리자</label>
+            <div class="manager-select-box">
+              <span v-if="editingDeptData.manager">{{ editingDeptData.manager.employeeName }} ({{ editingDeptData.manager.jobTitle }})</span>
+              <span v-else class="placeholder">관리자 없음</span>
+              <button @click="openEmployeeSearch" class="btn-search">검색</button>
+              <button v-if="editingDeptData.manager" @click="removeManager" class="btn-clear">삭제</button>
+            </div>
+          </div>
+          <div class="modal-actions">
+            <button @click="saveEditModal" class="btn-confirm">확인</button>
+            <button @click="closeEditModal" class="btn-cancel">취소</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 사원 검색 모달 -->
+    <div v-if="showEmployeeModal" class="modal-overlay" @click.self="closeEmployeeModal">
+      <div class="modal-content search-modal">
+        <div class="modal-header">
+          <h3>사원 검색</h3>
+        </div>
+        <div class="modal-body">
+          <div class="search-container">
+            <div class="filter-row">
+              <select v-model="searchParams.departmentName" class="filter-select">
+                <option value="">부서 전체</option>
+                <option v-for="opt in departmentOptions" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+              <select v-model="searchParams.jobTitleName" class="filter-select">
+                <option value="">직책 전체</option>
+                <option v-for="opt in jobTitleOptions" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+              <select v-model="searchParams.gradeName" class="filter-select">
+                <option value="">직급 전체</option>
+                <option v-for="opt in gradeOptions" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+            </div>
+            <div class="search-row">
+              <input v-model="searchParams.employeeName" @keyup.enter="searchEmployees(0)" type="text" placeholder="사원명 입력" class="form-input" />
+              <button @click="searchEmployees(0)" class="btn-search-action">검색</button>
+            </div>
+          </div>
+          <div class="employee-list">
+            <div v-if="isLoadingEmployees" class="loading-sm">로딩 중...</div>
+            <ul v-else-if="employeeList.length > 0">
+              <li v-for="emp in employeeList" :key="emp.employeeId" @click="selectManager(emp)" class="employee-item">
+                <span class="emp-name">{{ emp.employeeName }}</span>
+                <span class="emp-info">{{ emp.departmentName }} / {{ emp.jobTitleName }} / {{ emp.gradeName }}</span>
+              </li>
+            </ul>
+            <div v-else class="no-result">검색 결과가 없습니다.</div>
+          </div>
+          <!-- 페이지네이션 -->
+          <div class="pagination" v-if="totalPages > 0">
+            <button :disabled="currentPage === 0" @click="searchEmployees(currentPage - 1)">&lt;</button>
+            <span>{{ currentPage + 1 }} / {{ totalPages }}</span>
+            <button :disabled="currentPage >= totalPages - 1" @click="searchEmployees(currentPage + 1)">&gt;</button>
+          </div>
+          <div class="modal-actions">
+            <button @click="closeEmployeeModal" class="btn-cancel">닫기</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue';
+import { useSettingsStore } from '@/stores/settings';
+import { saveOrUpdateDepartments } from '@/api/settings';
+// 사원 검색 API (가정) - 실제 경로에 맞게 수정 필요
+import { fetchEmployees, fetchEmployeeSearchOptions } from '@/api/personnel'; 
+import type { SettingsDepartmentRequestDTO, SettingsDepartmentResponseDTO } from '@/types/settings';
+import DepartmentTreeItem from '@/views/settings/DepartmentTreeItem.vue';
+
+const settingsStore = useSettingsStore();
+const localDepartments = ref<SettingsDepartmentResponseDTO[]>([]);
+
+watch(() => settingsStore.departments, (newVal: any) => {
+  console.log('Department watch newVal:', newVal);
+  // API 응답이 { data: [...] } 형태일 경우와 배열 [...] 형태일 경우를 모두 처리
+  const data = (newVal && !Array.isArray(newVal) && newVal.data) ? newVal.data : newVal;
+  localDepartments.value = data ? JSON.parse(JSON.stringify(data)) : [];
+}, { immediate: true, deep: true });
+
+// 저장 로직
+const saveDepartments = async () => {
+  try {
+    // 스토어의 데이터를 Request DTO 형태로 변환
+    const requestData = convertToRequestDTO(localDepartments.value);
+    
+    const res = await saveOrUpdateDepartments(requestData);
+    if (res.success) {
+      alert('부서 정보가 저장되었습니다.');
+      await settingsStore.fetchDepartments(); // 최신 데이터 재조회
+    } else {
+      alert('저장 실패: ' + res.message);
+    }
+  } catch (error) {
+    console.error(error);
+    alert('저장 중 오류가 발생했습니다.');
+  }
+};
+
+// ResponseDTO -> RequestDTO 변환 헬퍼
+const convertToRequestDTO = (data: any[]): SettingsDepartmentRequestDTO[] => {
+  return data.map(dept => ({
+    // 음수 ID(신규)는 null로 변환
+    departmentId: dept.departmentId > 0 ? dept.departmentId : null,
+    departmentName: dept.departmentName,
+    departmentPhone: dept.departmentPhone,
+    depth: dept.depth,
+    parentDepartmentId: dept.parentDepartmentId > 0 ? dept.parentDepartmentId : null,
+    managerId: dept.manager?.employeeId || null,
+    children: dept.children ? convertToRequestDTO(dept.children) : []
+  }));
+};
+
+const addRootDepartment = () => {
+  // 임시 ID 생성 (음수)
+  const newId = -Date.now();
+  localDepartments.value.push({
+    departmentId: newId,
+    departmentName: '',
+    departmentPhone: '',
+    depth: 0,
+    parentDepartmentId: null,
+    manager: null,
+    children: []
+  });
+};
+
+const handleAddDepartment = (parentDept: any) => {
+  if (!parentDept.children) {
+    parentDept.children = [];
+  }
+  const newId = -Date.now();
+  parentDept.children.push({
+    departmentId: newId,
+    departmentName: '',
+    departmentPhone: '',
+    depth: parentDept.depth + 1,
+    parentDepartmentId: parentDept.departmentId > 0 ? parentDept.departmentId : null,
+    manager: null,
+    children: []
+  });
+};
+
+const handleRemoveDepartment = (index: number) => {
+  localDepartments.value.splice(index, 1);
+};
+
+// --- 모달 관련 로직 ---
+const showEditModal = ref(false);
+const showEmployeeModal = ref(false);
+const editingDeptRef = ref<SettingsDepartmentResponseDTO | null>(null); // 원본 참조
+const editingDeptData = ref<any>({}); // 수정 중인 데이터 복사본
+
+const handleEditDepartment = (dept: SettingsDepartmentResponseDTO) => {
+  editingDeptRef.value = dept;
+  // 깊은 복사로 수정 중 데이터 분리
+  editingDeptData.value = JSON.parse(JSON.stringify(dept));
+  showEditModal.value = true;
+};
+
+const closeEditModal = () => {
+  showEditModal.value = false;
+  editingDeptRef.value = null;
+  editingDeptData.value = {};
+};
+
+const saveEditModal = () => {
+  if (editingDeptRef.value) {
+    // 원본 데이터 업데이트
+    editingDeptRef.value.departmentName = editingDeptData.value.departmentName;
+    editingDeptRef.value.departmentPhone = editingDeptData.value.departmentPhone;
+    editingDeptRef.value.manager = editingDeptData.value.manager;
+  }
+  closeEditModal();
+};
+
+const removeManager = () => {
+  editingDeptData.value.manager = null;
+};
+
+// --- 사원 검색 관련 로직 ---
+const searchParams = ref({
+  departmentName: '',
+  jobTitleName: '',
+  gradeName: '',
+  employeeName: ''
+});
+
+const departmentOptions = ref<string[]>([]);
+const gradeOptions = ref<string[]>([]);
+const jobTitleOptions = ref<string[]>([]);
+
+const employeeList = ref<any[]>([]);
+const isLoadingEmployees = ref(false);
+const currentPage = ref(0);
+const totalPages = ref(0);
+const pageSize = 5;
+
+const openEmployeeSearch = async () => {
+  showEmployeeModal.value = true;
+  // 검색 조건 초기화
+  searchParams.value = {
+    departmentName: '',
+    jobTitleName: '',
+    gradeName: '',
+    employeeName: ''
+  };
+  employeeList.value = [];
+  currentPage.value = 0;
+  totalPages.value = 0;
+  
+  // 옵션 로드
+  if (departmentOptions.value.length === 0) {
+    await loadSearchOptions();
+  }
+  
+  searchEmployees(0); // 초기 전체 조회
+};
+
+const closeEmployeeModal = () => {
+  showEmployeeModal.value = false;
+};
+
+const loadSearchOptions = async () => {
+  try {
+    const res = await fetchEmployeeSearchOptions();
+    if (res.data.success) {
+      departmentOptions.value = res.data.data.department;
+      gradeOptions.value = res.data.data.grade;
+      jobTitleOptions.value = res.data.data.jobTitle;
+    }
+  } catch (error) {
+    console.error('검색 옵션 로딩 실패:', error);
+  }
+};
+
+const searchEmployees = async (page: number = 0) => {
+  isLoadingEmployees.value = true;
+  try {
+    // API 호출: 검색어가 있으면 검색, 없으면 전체 조회
+    // fetchEmployees는 PageResponse를 반환하므로 content를 추출해야 함
+    const params: any = {
+      page: page + 1,
+      size: pageSize,
+      ...searchParams.value
+    };
+
+    const res = await fetchEmployees(params);
+    if (res.data && res.data.success && res.data.data) {
+      employeeList.value = res.data.data.content;
+      currentPage.value = res.data.data.page;
+      totalPages.value = res.data.data.totalPages;
+    }
+  } catch (error) {
+    console.error('사원 검색 실패:', error);
+  } finally {
+    isLoadingEmployees.value = false;
+  }
+};
+
+const selectManager = (emp: any) => {
+  // 선택한 사원을 관리자로 설정
+  // DTO 구조에 맞게 매핑
+  editingDeptData.value.manager = {
+    employeeId: emp.employeeId,
+    employeeName: emp.employeeName,
+    employeeNumber: emp.employeeNumber || '',
+    jobTitle: emp.jobTitleName || emp.jobTitle || '',
+    grade: emp.gradeName || emp.grade || ''
+  };
+  closeEmployeeModal();
+};
+
+onMounted(async () => {
+  await settingsStore.fetchDepartments();
+  console.log('Department onMounted store data:', settingsStore.departments);
+});
+</script>
+
+<style scoped>
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.page-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172b;
+}
+
+.btn-save {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  border: none;
+  padding: 10px 24px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.btn-save:hover {
+  background-color: #162456;
+}
+
+.loading-text {
+  text-align: center;
+  padding: 40px 0;
+  color: #64748b;
+}
+
+.tree-root {
+  padding: 0;
+  margin: 0;
+}
+
+.tree-container {
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 20px;
+  min-height: 400px;
+  max-height: 600px;
+  overflow-y: auto;
+}
+
+.tree-actions {
+  margin-bottom: 10px;
+  text-align: right;
+}
+
+.btn-add-root {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  border: none;
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: white;
+}
+
+.btn-add-root:hover {
+  background: #162456;
+}
+
+.no-data {
+  text-align: center;
+  padding: 40px 0;
+  color: #94a3b8;
+}
+
+/* 모달 스타일 */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 12px;
+  width: 400px;
+  max-width: 90%;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  padding: 16px 24px;
+  color: white;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.modal-body {
+  padding: 24px;
+}
+
+.search-modal {
+  width: 500px;
+}
+
+.form-group {
+  margin-bottom: 16px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 6px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.form-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.manager-select-box {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: #f8fafc;
+}
+
+.placeholder {
+  color: #94a3b8;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.btn-confirm, .btn-search-action {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.btn-cancel, .btn-search, .btn-clear {
+  background-color: #f1f5f9;
+  color: #475569;
+  border: 1px solid #cbd5e1;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.employee-list {
+  margin-top: 16px;
+  max-height: 300px;
+  overflow-y: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+}
+
+.employee-item {
+  padding: 10px;
+  border-bottom: 1px solid #f1f5f9;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+}
+
+.employee-item:hover {
+  background-color: #f8fafc;
+}
+
+.search-container {
+  margin-bottom: 16px;
+}
+
+.filter-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.filter-select {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  background-color: white;
+}
+
+.search-row {
+  display: flex;
+  gap: 8px;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+  font-size: 0.9rem;
+}
+
+.pagination button {
+  padding: 4px 10px;
+  border: 1px solid #cbd5e1;
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background-color: #f1f5f9;
+}
+</style>

--- a/hero-fe/src/views/settings/DepartmentTreeItem.vue
+++ b/hero-fe/src/views/settings/DepartmentTreeItem.vue
@@ -1,0 +1,163 @@
+<template>
+  <li class="tree-item" v-if="department">
+    <div class="item-content" @click.stop="$emit('edit', department)">
+      <div class="info-group">
+        <span class="dept-name">{{ department.departmentName || '(부서명 없음)' }}</span>
+        <span class="dept-info" v-if="department.departmentPhone">📞 {{ department.departmentPhone }}</span>
+        <span class="dept-info" v-if="department.manager">👤 {{ managerDisplay }}</span>
+      </div>
+      <div class="actions">
+        <button @click.stop="$emit('add', department)" class="btn-icon add" title="하위 부서 추가">+</button>
+        <button @click.stop="$emit('remove', department)" class="btn-icon remove" title="부서 삭제">-</button>
+      </div>
+    </div>
+    
+    <!-- 자식 부서가 있을 경우 재귀 호출 -->
+    <ul v-if="department.children && department.children.length" class="sub-tree">
+      <DepartmentTreeItem 
+        v-for="(child, index) in department.children" 
+        :key="child.departmentId" 
+        :department="child" 
+        @add="$emit('add', $event)"
+        @edit="$emit('edit', $event)"
+        @remove="handleChildRemove(index)"
+      />
+    </ul>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { SettingsDepartmentResponseDTO } from '@/types/settings';
+
+const props = defineProps<{
+  department: SettingsDepartmentResponseDTO;
+}>();
+
+defineEmits(['add', 'remove', 'edit']);
+
+const managerDisplay = computed(() => {
+  const mgr = props.department.manager;
+  if (mgr) {
+    return mgr.employeeName ? `${mgr.employeeName} ${mgr.jobTitle ? `(${mgr.jobTitle})` : ''}` : `(ID: ${mgr.employeeId})`;
+  }
+  return '';
+});
+
+const handleChildRemove = (index: number) => {
+  props.department.children.splice(index, 1);
+};
+</script>
+
+<style scoped>
+.tree-item {
+  list-style: none;
+  margin: 4px 0;
+}
+
+.item-content {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  margin-bottom: 4px;
+  justify-content: space-between;
+  min-height: 42px;
+}
+
+.dept-name {
+  font-weight: 600;
+  color: #334155;
+  margin-right: 8px;
+}
+
+.dept-info {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin-right: 8px;
+}
+
+.sub-tree {
+  padding-left: 24px;
+  border-left: 1px solid #e2e8f0;
+  margin-left: 12px;
+}
+
+/* 호버 효과 */
+.item-content:hover {
+  background-color: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+.actions {
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.item-content:hover .actions {
+  opacity: 1;
+}
+
+.btn-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  border: 1px solid #cbd5e1;
+  background: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
+
+.info-group {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.edit-form {
+  display: flex;
+  gap: 8px;
+  flex: 1;
+  margin-right: 8px;
+}
+
+.edit-input {
+  padding: 4px 8px;
+  border: 1px solid #cbd5e1;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  width: 120px;
+}
+
+.edit-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.btn-text {
+  padding: 4px 8px;
+  border: 1px solid #cbd5e1;
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.btn-text.save {
+  background-color: #3b82f6;
+  color: white;
+  border-color: #3b82f6;
+}
+
+.btn-text.cancel {
+  background-color: #f1f5f9;
+  color: #475569;
+}
+</style>

--- a/hero-fe/src/views/settings/Grade.vue
+++ b/hero-fe/src/views/settings/Grade.vue
@@ -1,0 +1,211 @@
+<template>
+  <div>
+    <div class="page-header">
+      <h2 class="page-title">직급 관리</h2>
+      <button @click="saveGrades" class="btn-save">
+        저장
+      </button>
+    </div>
+
+    <div class="table-container">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>직급명</th>
+            <th>필요 포인트</th>
+            <th class="w-100">관리</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(grade, index) in localGrades" :key="index">
+            <td>
+              <input
+                v-model="grade.grade"
+                type="text"
+                class="input-text"
+                placeholder="직급명 입력"
+              />
+            </td>
+            <td>
+              <input
+                v-model.number="grade.requiredPoint"
+                type="number"
+                class="input-text"
+                placeholder="0"
+              />
+            </td>
+            <td class="text-center">
+              <button @click="removeGrade(index)" class="btn-delete">
+                삭제
+              </button>
+            </td>
+          </tr>
+          <tr v-if="localGrades.length === 0">
+            <td colspan="3" class="no-data">
+              등록된 직급이 없습니다.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <button @click="addGrade" class="btn-add">
+        + 직급 추가
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue';
+import { useSettingsStore } from '@/stores/settings';
+import { updateGrades } from '@/api/settings';
+import type { Grade } from '@/types/settings';
+
+const settingsStore = useSettingsStore();
+const localGrades = ref<Grade[]>([]);
+
+watch(() => settingsStore.grades, (newVal: any) => {
+  console.log('Grade watch newVal:', newVal);
+  const data = (newVal && !Array.isArray(newVal) && newVal.data) ? newVal.data : newVal;
+  console.log('Grade processed data:', data);
+  localGrades.value = data ? JSON.parse(JSON.stringify(data)) : [];
+}, { immediate: true, deep: true });
+
+onMounted(async () => {
+  await settingsStore.fetchGrades();
+  console.log('Grade onMounted store data:', settingsStore.grades);
+});
+
+const addGrade = () => {
+  // 기존 ID 중 가장 작은 값을 찾아서 그보다 1 작은 값을 임시 ID로 사용 (음수 활용)
+  const minId = localGrades.value.reduce((min, item) => Math.min(min, item.gradeId), 0);
+  localGrades.value.push({ gradeId: minId - 1, grade: '', requiredPoint: 0 });
+};
+
+const removeGrade = (index: number) => {
+  localGrades.value.splice(index, 1);
+};
+
+const saveGrades = async () => {
+  try {
+    const payload = localGrades.value
+      .filter(item => item.gradeId !== 0)
+      .map(item => ({
+      // 음수 ID(새로 추가된 항목)는 null로 변환하여 전송 (신규 생성)
+      // 0 또는 양수 ID는 그대로 전송 (수정)
+      gradeId: item.gradeId < 0 ? null : item.gradeId,
+      gradeName: item.grade,
+      requiredPoint: item.requiredPoint
+    }));
+    console.log('Grade payload:', payload);
+    const res = await updateGrades(payload);
+    if (res.success) {
+      alert('직급 정보가 저장되었습니다.');
+      settingsStore.fetchGrades();
+    }
+  } catch (e) {
+    alert('저장 실패');
+  }
+};
+</script>
+
+<style scoped>
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.page-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172b;
+}
+
+.btn-save {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  border: none;
+  padding: 10px 24px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.btn-save:hover {
+  background-color: #162456;
+}
+
+.table-container {
+  overflow-x: auto;
+  /* overflow-y: auto; */
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  margin-bottom: 20px;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.data-table th, .data-table td {
+  padding: 15px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.data-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.input-text {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.btn-delete {
+  color: #ef4444;
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+.no-data {
+  padding: 40px 0;
+  text-align: center;
+  color: #94a3b8;
+}
+
+.btn-add {
+  width: 100%;
+  padding: 12px;
+  border: 2px dashed #e2e8f0;
+  color: #64748b;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-add:hover {
+  background-color: #f8fafc;
+}
+
+.w-100 {
+  width: 100px;
+  text-align: center;
+}
+</style>

--- a/hero-fe/src/views/settings/JobTitle.vue
+++ b/hero-fe/src/views/settings/JobTitle.vue
@@ -1,0 +1,197 @@
+<template>
+  <div>
+    <div class="page-header">
+      <h2 class="page-title">직책 관리</h2>
+      <button @click="saveJobTitles" class="btn-save">
+        저장
+      </button>
+    </div>
+
+    <div class="table-container">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>직책명</th>
+            <th class="w-100">관리</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(job, index) in localJobTitles" :key="index">
+            <td>
+              <input
+                v-model="job.jobTitle"
+                type="text"
+                class="input-text"
+                placeholder="직책명 입력"
+              />
+            </td>
+            <td class="text-center">
+              <button @click="removeJobTitle(index)" class="btn-delete">
+                삭제
+              </button>
+            </td>
+          </tr>
+          <tr v-if="localJobTitles.length === 0">
+            <td colspan="2" class="no-data">
+              등록된 직책이 없습니다.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <button @click="addJobTitle" class="btn-add">
+        + 직책 추가
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue';
+import { useSettingsStore } from '@/stores/settings';
+import { updateJobTitles } from '@/api/settings';
+import type { JobTitle } from '@/types/settings';
+
+const settingsStore = useSettingsStore();
+const localJobTitles = ref<JobTitle[]>([]);
+
+watch(() => settingsStore.jobTitles, (newVal: any) => {
+  console.log('JobTitle watch newVal:', newVal);
+  const data = (newVal && !Array.isArray(newVal) && newVal.data) ? newVal.data : newVal;
+  localJobTitles.value = data ? JSON.parse(JSON.stringify(data)) : [];
+}, { immediate: true, deep: true });
+
+onMounted(async () => {
+  await settingsStore.fetchJobTitles();
+  console.log('JobTitle onMounted store data:', settingsStore.jobTitles);
+});
+
+const addJobTitle = () => {
+const minId = localJobTitles.value.reduce((min, item) => Math.min(min, item.jobTitleId), 0);
+  localJobTitles.value.push({ jobTitleId: minId - 1, jobTitle: '' });
+
+};
+
+const removeJobTitle = (index: number) => {
+  localJobTitles.value.splice(index, 1);
+};
+
+const saveJobTitles = async () => {
+  try {
+    const payload = localJobTitles.value
+    .filter(item => item.jobTitleId !== 0)
+    .map(item => ({
+      jobTitleId: item.jobTitleId < 0 ? null : item.jobTitleId,
+      jobTitleName: item.jobTitle
+    }));
+    const res = await updateJobTitles(payload);
+    if (res.success) {
+      alert('직책 정보가 저장되었습니다.');
+      settingsStore.fetchJobTitles();
+    }
+  } catch (e) {
+    alert('저장 실패');
+  }
+};
+</script>
+
+<style scoped>
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.page-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172b;
+}
+
+.btn-save {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  border: none;
+  padding: 10px 24px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.btn-save:hover {
+  background-color: #162456;
+}
+
+.table-container {
+  overflow-x: auto;
+  /* overflow-y: auto; */
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  margin-bottom: 20px;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.data-table th, .data-table td {
+  padding: 15px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.data-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.input-text {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.btn-delete {
+  color: #ef4444;
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+.no-data {
+  padding: 40px 0;
+  text-align: center;
+  color: #94a3b8;
+}
+
+.btn-add {
+  width: 100%;
+  padding: 12px;
+  border: 2px dashed #e2e8f0;
+  color: #64748b;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-add:hover {
+  background-color: #f8fafc;
+}
+
+.w-100 {
+  width: 100px;
+  text-align: center;
+}
+</style>

--- a/hero-fe/src/views/settings/Permission.vue
+++ b/hero-fe/src/views/settings/Permission.vue
@@ -1,0 +1,356 @@
+<template>
+  <div>
+    <div class="page-header">
+      <h2 class="page-title">사원 권한 관리</h2>
+    </div>
+    
+    <!-- 검색 -->
+    <div class="search-container">
+      <input v-model="searchQuery" @keyup.enter="fetchData" type="text" placeholder="사원명 검색" class="search-input" />
+      <button @click="fetchData" class="btn-search">검색</button>
+    </div>
+
+    <!-- 테이블 -->
+    <div class="table-container">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>사원명 (사번)</th>
+            <th>부서</th>
+            <th>직급/직책</th>
+            <th>권한</th>
+            <th>관리</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="emp in permissions" :key="emp.employeeId">
+            <td>{{ emp.employeeName }} ({{ emp.employeeId }})</td>
+            <td>{{ emp.department }}</td>
+            <td>{{ emp.grade }} / {{ emp.jobTitle }}</td>
+            <td>
+              <div class="role-badges">
+                <span v-for="role in emp.role" :key="role" class="badge">
+                  {{ role }}
+                </span>
+              </div>
+            </td>
+            <td>
+              <button @click="openEditModal(emp)" class="btn-edit">수정</button>
+            </td>
+          </tr>
+          <tr v-if="permissions.length === 0">
+            <td colspan="5" class="no-data">검색 결과가 없습니다.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- 페이지네이션 -->
+    <div class="pagination-container">
+      <button 
+        v-for="p in totalPages" 
+        :key="p" 
+        @click="changePage(p)"
+        :class="['page-btn', currentPage === p ? 'active' : '']"
+      >
+        {{ p }}
+      </button>
+    </div>
+
+    <!-- 권한 수정 모달 -->
+    <Teleport to="body">
+      <div v-if="editingEmployee" class="modal-overlay" @click.self="editingEmployee = null">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h3>권한 수정 - {{ editingEmployee.employeeName }} ({{ editingEmployee.employeeId }})</h3>
+          </div>
+          <div class="modal-body">
+            <div class="checkbox-group select-all">
+              <input 
+                type="checkbox" 
+                id="role-all" 
+                v-model="isAllSelected"
+                class="checkbox-input"
+              >
+              <label for="role-all" class="label-bold">전체 선택</label>
+            </div>
+            <div v-for="role in settingsStore.roles" :key="role.roleId" class="checkbox-group">
+              <input 
+                type="checkbox" 
+                :id="'role-' + role.roleId" 
+                :value="role.roleId" 
+                v-model="selectedRoleIds"
+                class="checkbox-input"
+              >
+              <label :for="'role-' + role.roleId">{{ role.roleName }}</label>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button @click="savePermissions" class="btn-save-modal">저장</button>
+            <button @click="editingEmployee = null" class="btn-cancel">취소</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue';
+import { useSettingsStore } from '@/stores/settings';
+import { getPermissions, updatePermissions } from '@/api/settings';
+import type { SettingsPermissionsResponseDTO } from '@/types/settings';
+
+const settingsStore = useSettingsStore();
+const permissions = ref<SettingsPermissionsResponseDTO[]>([]);
+const currentPage = ref(1);
+const totalPages = ref(1);
+const searchQuery = ref('');
+
+const editingEmployee = ref<SettingsPermissionsResponseDTO | null>(null);
+const selectedRoleIds = ref<number[]>([]);
+
+const isAllSelected = computed({
+  get: () => settingsStore.roles.length > 0 && selectedRoleIds.value.length === settingsStore.roles.length,
+  set: (val) => {
+    if (val) {
+      selectedRoleIds.value = settingsStore.roles.map(r => r.roleId);
+    } else {
+      selectedRoleIds.value = [];
+    }
+  }
+});
+
+const fetchData = async () => {
+  const res = await getPermissions(currentPage.value - 1, 10, searchQuery.value);
+  if (res.success) {
+    permissions.value = res.data.content;
+    totalPages.value = res.data.totalPages;
+  }
+};
+
+const changePage = (page: number) => {
+  currentPage.value = page;
+  fetchData();
+};
+
+const openEditModal = (emp: SettingsPermissionsResponseDTO) => {
+  editingEmployee.value = emp;
+  selectedRoleIds.value = settingsStore.roles
+    .filter(r => emp.role.includes(r.roleName))
+    .map(r => r.roleId);
+};
+
+const savePermissions = async () => {
+  if (!editingEmployee.value) return;
+  const res = await updatePermissions({
+    employeeId: editingEmployee.value.employeeId,
+    roleIds: selectedRoleIds.value
+  });
+  if (res.success) {
+    alert('권한이 수정되었습니다.');
+    editingEmployee.value = null;
+    fetchData();
+  }
+};
+
+onMounted(async () => {
+  await settingsStore.fetchRoles();
+  fetchData();
+});
+</script>
+
+<style scoped>
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.page-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172b;
+}
+
+.search-container {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.search-input {
+  width: 300px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+.btn-search {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  border: none;
+  padding: 8px 24px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.table-container {
+  overflow-x: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  margin-bottom: 20px;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.data-table th, .data-table td {
+  padding: 15px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.data-table th {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.role-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.badge {
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  background-color: #e0e7ff;
+  color: #3730a3;
+}
+
+.btn-edit {
+  color: #2563eb;
+  font-weight: 500;
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+
+.pagination-container {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.page-btn {
+  padding: 6px 12px;
+  border: 1px solid #e2e8f0;
+  background: white;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.page-btn.active {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  border: none;
+}
+
+.no-data {
+  text-align: center;
+  padding: 40px 0;
+  color: #94a3b8;
+}
+
+/* Modal Styles */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 12px;
+  width: 400px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.modal-header {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  padding: 16px 24px;
+  color: white;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.modal-body {
+  padding: 24px;
+}
+
+.checkbox-group {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.checkbox-input {
+  margin-right: 8px;
+}
+
+.select-all {
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.label-bold {
+  font-weight: 600;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 0 24px 24px;
+}
+
+.btn-cancel {
+  background-color: #f1f5f9;
+  color: #4b5563;
+  border: 1px solid #cbd5e1;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.btn-save-modal {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+</style>

--- a/hero-fe/src/views/settings/Settings.vue
+++ b/hero-fe/src/views/settings/Settings.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="page-container">
+    <div class="header-container">
+      <h2 class="page-title">시스템 설정</h2>
+    </div>
+
+    <div class="content-wrapper">
+      <div class="main-card">
+        <!-- 탭 메뉴 -->
+        <div class="tabs-container">
+          <button
+            v-for="tab in tabs"
+            :key="tab.id"
+            @click="changeTab(tab)"
+            :class="['tab-button', isActive(tab) ? 'active' : '']"
+          >
+            {{ tab.label }}
+          </button>
+        </div>
+
+        <!-- 탭 컨텐츠 -->
+        <div class="content-container">
+          <router-view />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { useSettingsStore } from '@/stores/settings';
+
+const settingsStore = useSettingsStore();
+const router = useRouter();
+const route = useRoute();
+
+const tabs = [
+  { id: 'department', label: '부서 관리', path: '/settings/department' },
+  { id: 'grade', label: '직급 관리', path: '/settings/grade' },
+  { id: 'jobTitle', label: '직책 관리', path: '/settings/jobTitle' },
+  { id: 'permission', label: '권한 관리', path: '/settings/permission' },
+];
+
+const changeTab = (tab: any) => {
+  router.push(tab.path);
+};
+
+const isActive = (tab: any) => {
+  return route.path.includes(tab.path);
+};
+
+onMounted(() => {
+  // 설정 페이지 진입 시 필요한 데이터 로드
+  // settingsStore.loadAllSettings();
+});
+</script>
+
+<style scoped>
+.page-container {
+  background-color: #f8fafc;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header-container {
+  width: 100%;
+  height: 50px;
+  background: white;
+  padding: 20px;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.page-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172b;
+}
+
+.content-wrapper {
+  padding: 20px;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.main-card {
+  background: white;
+  border-radius: 14px;
+  border: 1px solid #e2e8f0;
+  min-height: 600px;
+}
+
+.tabs-container {
+  display: flex;
+  padding: 0 20px;
+  background: white;
+  border-bottom: 1px solid #e2e8f0;
+  border-radius: 14px 14px 0 0;
+  padding-top: 12px;
+}
+
+.tab-button {
+  padding: 10px 24px;
+  margin-right: 8px;
+  font-weight: 500;
+  color: #64748b;
+  background: none;
+  border: none;
+  border-radius: 8px 8px 0 0;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.tab-button:hover {
+  color: #1c398e;
+  background-color: #f8fafc;
+}
+
+.tab-button.active {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+}
+
+.content-container {
+  padding: 24px;
+}
+</style>


### PR DESCRIPTION
## 📋 작업 내용
관리자용 시스템 설정(Settings) 페이지 레이아웃 및 탭 기능 구현
부서 관리: 조직도 트리 뷰, 부서 추가/수정/삭제, 부서장 지정 기능 구현
직급/직책 관리: 목록 조회, 인라인 편집, 추가/삭제 및 일괄 저장 기능 구현
권한 관리: 사원별 권한 조회 및 수정(모달) 기능 구현
사이드바에 '설정' 메뉴 추가 및 라우팅 연결

## 🔧 작업 상세

### 변경된 파일
src/views/settings/Settings.vue: 설정 메인 페이지 (탭 레이아웃 구성)
src/views/settings/Department.vue: 부서 관리 페이지 (트리 구조 및 모달 로직)
src/views/settings/DepartmentTreeItem.vue: 부서 트리 재귀 컴포넌트
src/views/settings/Grade.vue: 직급 관리 페이지 (테이블 인라인 편집)
src/views/settings/JobTitle.vue: 직책 관리 페이지 (테이블 인라인 편집)
src/views/settings/Permission.vue: 권한 관리 페이지 (사원 검색 및 권한 수정)
src/components/layout/TheSidebar.vue: 사이드바 메뉴에 '설정' 탭 추가

### 주요 로직 설명
부서 관리 (Tree View): DepartmentTreeItem 컴포넌트를 재귀적으로 호출하여 계층형 조직도를 구현했습니다. 부서 추가 시 음수 ID를 임시로 부여하여 신규 항목임을 식별합니다.
직급/직책 관리 (Inline Edit): 별도의 수정 모달 없이 테이블 내에서 직접 input을 통해 데이터를 수정하고, '저장' 버튼 클릭 시 변경된 데이터만 필터링하여 일괄 전송하도록 구현했습니다.
권한 관리: SYSTEM_ADMIN 권한을 가진 사용자는 목록에서 수정 버튼을 비활성화하여 실수로 인한 관리자 권한 박탈을 방지했습니다.
## ✅ 테스트 체크리스트
[ ] /settings 경로 진입 시 탭 메뉴가 정상적으로 표시되는지 확인
[ ] 부서 관리: 최상위/하위 부서 추가 및 삭제가 트리 구조에 즉시 반영되는지 확인
[ ] 부서 관리: 부서장 검색 모달이 열리고, 사원 선택 시 정상적으로 매핑되는지 확인
[ ] 직급/직책: 행 추가 후 데이터 입력 및 저장 시 DB 반영 여부 확인
[ ] 권한 관리: 사원명 검색이 정상 동작하며, 권한 수정 후 '저장' 시 반영되는지 확인
[ ] 사이드바의 '설정' 메뉴 클릭 시 해당 페이지로 이동하는지 확인

## 🖼️ 스크린샷 (UI 변경 시)

## 🤔 리뷰 포인트
[Permission.vue](code-assist-path:c:\SWCamp_19th\Project_fin\Hero-FE\hero-fe\src\views\settings\Permission.vue)에서 권한 수정 시 SYSTEM_ADMIN 예외 처리 로직이 충분한지 봐주시면 감사하겠습니다.

## 🔗 관련 이슈
- Closes #57 
- Related to #57 
- Resolves #57 
