### PR TITLE
[Feat] 승진 추천 페이지 기능 구현

### DIFF
--- a/hero-fe/src/api/personnel/promotion.api.ts
+++ b/hero-fe/src/api/personnel/promotion.api.ts
@@ -84,7 +84,7 @@ export const registerPromotionPlan = (data: PromotionPlanRequestDTO) => {
  * 현재 로그인한 사람의 부서를 이용해 관련된 승진 계획 조회
  */
 export const fetchRecommendPromotionPlans = () => {
-    return client.get<ApiResponse<PromotionPlanResponseDTO[]>>('/promotion/plan/recommend');
+    return client.get<ApiResponse<PromotionPlanResponseDTO[]>>('/promotion/nominations');
 }
 
 /**
@@ -92,7 +92,7 @@ export const fetchRecommendPromotionPlans = () => {
  * @param promotionId 
  */
 export const fetchRecommendPromotionPlanDetail = (promotionId: number) => {
-    return client.get<ApiResponse<PromotionPlanDetailResponseDTO>>(`/promotion/plan/recommend/${promotionId}`);
+    return client.get<ApiResponse<PromotionPlanDetailResponseDTO>>(`/promotion/nominations/${promotionId}`);
 }
 
 /**
@@ -100,7 +100,7 @@ export const fetchRecommendPromotionPlanDetail = (promotionId: number) => {
  * @param data 
  */
 export const nominateCandidate = (data: PromotionNominationRequestDTO) => {
-    return client.post<ApiResponse<void>>('/promotion/nominate', data);
+    return client.post<ApiResponse<void>>('/promotion/nominations', data);
 }
 
 /**
@@ -108,5 +108,5 @@ export const nominateCandidate = (data: PromotionNominationRequestDTO) => {
  * @param candidateId 
  */
 export const cancelNomination = (candidateId: number) => {
-    return client.delete<ApiResponse<void>>(`/promotion/nominate/${candidateId}`);
+    return client.delete<ApiResponse<void>>(`/promotion/nominations/${candidateId}`);
 }

--- a/hero-fe/src/api/personnel/promotion.api.ts
+++ b/hero-fe/src/api/personnel/promotion.api.ts
@@ -22,6 +22,7 @@ import type {
     PromotionDetailPlanDTO,
     //request
     PromotionPlanRequestDTO,
+    PromotionNominationRequestDTO,
     //response
     PromotionOptionsDTO,
     PromotionPlanResponseDTO,
@@ -77,4 +78,35 @@ export const fetchPromotionPlanDetail = (promotionId: number) => {
  */
 export const registerPromotionPlan = (data: PromotionPlanRequestDTO) => {
     return client.post<ApiResponse<void>>('/promotion/plan', data);
+}
+
+/**
+ * 현재 로그인한 사람의 부서를 이용해 관련된 승진 계획 조회
+ */
+export const fetchRecommendPromotionPlans = () => {
+    return client.get<ApiResponse<PromotionPlanResponseDTO[]>>('/promotion/plan/recommend');
+}
+
+/**
+ * 현재 로그인한 사람의 부서를 이용해 관련된 승진 계획의 상세 정보를 조회 (본인 부서 및 하위 부서원만 포함)
+ * @param promotionId 
+ */
+export const fetchRecommendPromotionPlanDetail = (promotionId: number) => {
+    return client.get<ApiResponse<PromotionPlanDetailResponseDTO>>(`/promotion/plan/recommend/${promotionId}`);
+}
+
+/**
+ * 승진 후보자 추천
+ * @param data 
+ */
+export const nominateCandidate = (data: PromotionNominationRequestDTO) => {
+    return client.post<ApiResponse<void>>('/promotion/nominate', data);
+}
+
+/**
+ * 승진 후보자 추천 취소
+ * @param candidateId 
+ */
+export const cancelNomination = (candidateId: number) => {
+    return client.delete<ApiResponse<void>>(`/promotion/nominate/${candidateId}`);
 }

--- a/hero-fe/src/router/modules/personnel.ts
+++ b/hero-fe/src/router/modules/personnel.ts
@@ -53,6 +53,14 @@ const personnelRoutes: RouteRecordRaw[] = [
           title: '승진 계획 상세',
         }
       },
+      {
+        path: 'recommend',
+        name: 'promotionRecommend',
+        component: () => import('@/views/personnel/recommend/Recommend.vue'),
+        meta: {
+          title: '승진 추천',
+        }
+      }
     ],
   }
 ];

--- a/hero-fe/src/stores/personnel/promotionRecommend.store.ts
+++ b/hero-fe/src/stores/personnel/promotionRecommend.store.ts
@@ -1,0 +1,106 @@
+/**
+ * <pre>
+ * File Name   : promotionRecommend.store.ts
+ * Description : 승진 추천 관련 상태 관리 (Pinia)
+ *               - 부서장의 승진 후보자 추천 및 조회 기능 담당
+ *
+ * History
+ * 2025/12/22 - 승건 Store 분리 (promotion.store.ts -> promotionRecommend.store.ts)
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { 
+    fetchRecommendPromotionPlans, 
+    fetchRecommendPromotionPlanDetail, 
+    nominateCandidate, 
+    cancelNomination 
+} from '@/api/personnel/promotion.api';
+import type { 
+    PromotionPlanResponseDTO, 
+    PromotionPlanDetailResponseDTO, 
+    PromotionNominationRequestDTO 
+} from '@/types/personnel/promotion.types';
+
+export const usePromotionRecommendStore = defineStore('promotion-recommend', () => {
+    const recommendPlans = ref<PromotionPlanResponseDTO[]>([]);
+    const recommendPlanDetail = ref<PromotionPlanDetailResponseDTO | null>(null);
+    const loading = ref(false);
+
+    const getRecommendPlans = async () => {
+        loading.value = true;
+        try {
+            const response = await fetchRecommendPromotionPlans();
+            if (response.data.success) {
+                console.log('Store: 추천 계획 목록 수신:', response.data.data);
+                recommendPlans.value = response.data.data;
+            } else {
+                console.error('추천 가능 계획 조회 API 실패:', response.data.error);
+                recommendPlans.value = [];
+            }
+        } catch (error) {
+            console.error('추천 가능 계획 조회 실패:', error);
+            recommendPlans.value = [];
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    const getRecommendDetail = async (id: number) => {
+        loading.value = true;
+        try {
+            const response = await fetchRecommendPromotionPlanDetail(id);
+            if (response.data.success) {
+                console.log('Store: 상세 조회 데이터 수신:', response.data.data);
+                recommendPlanDetail.value = response.data.data;
+            } else {
+                console.error('추천 상세 조회 API 실패:', response.data.error);
+                recommendPlanDetail.value = null;
+            }
+        } catch (error) {
+            console.error('추천 상세 조회 실패:', error);
+            recommendPlanDetail.value = null;
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    const requestNomination = async (data: PromotionNominationRequestDTO) => {
+        loading.value = true;
+        try {
+            const response = await nominateCandidate(data);
+            return response.data.success;
+        } catch (error) {
+            console.error('후보자 추천 실패:', error);
+            return false;
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    const requestCancelNomination = async (candidateId: number) => {
+        loading.value = true;
+        try {
+            const response = await cancelNomination(candidateId);
+            return response.data.success;
+        } catch (error) {
+            console.error('추천 취소 실패:', error);
+            return false;
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    return {
+        recommendPlans,
+        recommendPlanDetail,
+        loading,
+        getRecommendPlans,
+        getRecommendDetail,
+        requestNomination,
+        requestCancelNomination
+    };
+});

--- a/hero-fe/src/types/personnel/promotion.types.ts
+++ b/hero-fe/src/types/personnel/promotion.types.ts
@@ -36,6 +36,7 @@ export interface PromotionDepartmentDTO {
  * 승진 후보자를 알기 위한 DTO
  */
 export interface PromotionCandidateDTO {
+    candidateId?: number,
     employeeId?: number,
     employeeName?: string,
     employeeNumber?: string,
@@ -53,6 +54,7 @@ export interface PromotionCandidateDTO {
  * 승진의 상세 계획을 담기 위한 DTO
  */
 export interface PromotionDetailPlanDTO {
+    promotionDetailId?: number,
     departmentId?: number,
     department?: string,
     gradeId?: number,
@@ -72,6 +74,15 @@ export interface PromotionPlanRequestDTO {
     appointmentAt?: string,
     detailPlan?: PromotionDetailPlanDTO[],
     planContent?: string
+}
+
+/**
+ * 승진 후보자 추천 요청 DTO
+ */
+export interface PromotionNominationRequestDTO {
+    promotionId: number;
+    candidateId: number;
+    nominationReason: string;
 }
 
 // --- Response DTOs (응답 데이터) ---

--- a/hero-fe/src/views/personnel/recommend/Recommend.vue
+++ b/hero-fe/src/views/personnel/recommend/Recommend.vue
@@ -152,11 +152,11 @@
                 <span class="label">평가점수</span>
                 <span class="val">{{ candidate.evaluationPoint }}점</span>
               </div>
-              <div class="stat-row" v-if="candidate.isNominated && candidate.nominatorName">
+              <div class="stat-row" v-if="candidate.nominatorName">
                 <span class="label">추천자</span>
                 <span class="val">{{ candidate.nominatorName }}</span>
               </div>
-              <div class="stat-row" v-if="candidate.isNominated && candidate.nominationReason">
+              <div class="stat-row" v-if="candidate.nominationReason">
                 <span class="label">추천사유</span>
                 <span class="val">{{ candidate.nominationReason }}</span>
               </div>
@@ -173,7 +173,7 @@
 
             <div class="member-action">
               <button 
-                v-if="!candidate.isNominated"
+                v-if="!candidate.nominatorName && !candidate.nominationReason"
                 class="btn-recommend"
                 @click.stop="startNomination(candidate)"
               >
@@ -280,11 +280,10 @@ const confirmNomination = async (candidate: any) => {
   });
   
   if (success) {
-    candidate.isNominated = true;
     // API가 추천자 이름과 사유를 바로 반환하지 않는 경우를 대비하여 프론트에서 채워줌
     candidate.nominationReason = nominationReasonInput.value;
     // 추천자 이름은 현재 로그인한 사용자 정보로 채워야 하지만, 해당 정보가 없으므로 임시 처리
-    // candidate.nominatorName = '나'; 
+    candidate.nominatorName = '나(임시)'; 
     alert(`${candidate.employeeName || '후보자'} 님을 추천하였습니다.`);
     cancelActiveNomination(); // 입력 폼 닫기
   } else {
@@ -300,7 +299,6 @@ const cancelCandidateNomination = async (candidate: any) => {
   
   const success = await store.requestCancelNomination(candidate.candidateId);
   if (success) {
-    candidate.isNominated = false;
     // 추천 취소 시 관련 정보 초기화
     candidate.nominationReason = null;
     candidate.nominatorName = null;
@@ -654,7 +652,7 @@ onMounted(() => {
 }
 
 .member-card.nominated {
-  border-color: #3b82f6;
+  border-color: #1c398e;
   background: #eff6ff;
 }
 
@@ -677,7 +675,7 @@ onMounted(() => {
 }
 
 .member-card.nominated .avatar {
-  background: #3b82f6;
+  background: #1c398e;
   color: white;
 }
 

--- a/hero-fe/src/views/personnel/recommend/Recommend.vue
+++ b/hero-fe/src/views/personnel/recommend/Recommend.vue
@@ -1,0 +1,819 @@
+<template>
+  <div class="promotion-recommend-container">
+    <!-- 헤더 영역 -->
+    <div class="header-section">
+      <div class="header-inner">
+        <div class="header-left">
+          <button v-if="step > 1" class="btn-back-icon" @click="step--">←</button>
+          <h1 class="page-title">승진 추천</h1>
+        </div>
+        
+        <!-- 단계 표시 (Breadcrumbs) -->
+        <div class="breadcrumbs" v-if="step > 1">
+          <span class="crumb" :class="{ active: step === 1 }" @click="step = 1">계획 선택</span>
+          <span class="separator">›</span>
+          <span class="crumb" :class="{ active: step === 2 }" @click="step > 2 ? step = 2 : null">대상 그룹</span>
+          <span class="separator">›</span>
+          <span class="crumb" :class="{ active: step === 3 }">후보자 추천</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- 로딩 상태 -->
+    <div v-if="loading" class="loading-state">
+      <div class="spinner"></div>
+      <p>데이터를 불러오는 중입니다...</p>
+    </div>
+
+    <!-- 메인 컨텐츠 영역 -->
+    <div v-else class="content-area">
+      
+      <!-- STEP 1: 승진 계획 목록 -->
+      <div v-if="step === 1" class="step-wrapper fade-in">
+        <div class="section-header">
+          <h2>진행 중인 승진 계획</h2>
+          <p class="sub-desc">승진 추천을 진행할 계획을 선택해주세요.</p>
+        </div>
+
+        <div v-if="recommendPlans.length === 0" class="no-data">
+          <p>현재 추천 가능한 승진 계획이 없습니다.</p>
+        </div>
+
+        <div class="card-grid">
+          <div 
+            v-for="plan in recommendPlans" 
+            :key="plan.promotionId" 
+            class="plan-card"
+            @click="handleSelectPlan(plan)"
+          >
+            <div class="card-top">
+              <span class="status-badge">진행중</span>
+              <span class="date-label">{{ formatDate(plan.createdAt) }} 등록</span>
+            </div>
+            <h3 class="card-title">{{ plan.planName }}</h3>
+            <div class="card-info">
+              <div class="info-row">
+                <span class="label">추천 마감</span>
+                <span class="value">{{ formatDate(plan.nominationDeadlineAt) }}</span>
+              </div>
+              <div class="info-row">
+                <span class="label">발령 예정</span>
+                <span class="value">{{ formatDate(plan.appointmentAt) }}</span>
+              </div>
+            </div>
+            <div class="card-action">
+              <span>선택하기</span>
+              <span class="arrow">→</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- STEP 2: 상세 계획 (대상 그룹) 선택 -->
+      <div v-if="step === 2 && recommendPlanDetail" class="step-wrapper fade-in">
+        <div class="section-header">
+          <div>
+            <h2>{{ recommendPlanDetail.planName }}</h2>
+            <p class="sub-desc">추천을 진행할 대상 그룹(부서/직급)을 선택해주세요.</p>
+          </div>
+        </div>
+
+        <div class="plan-content-box">
+          {{ recommendPlanDetail.planContent || '상세 내용이 없습니다.' }}
+        </div>
+
+        <div class="card-grid detail-grid">
+          <div 
+            v-for="(detail, index) in recommendPlanDetail.detailPlan" 
+            :key="index"
+            class="detail-card"
+            @click="handleSelectDetail(detail)"
+          >
+            <div class="detail-icon">
+              <!-- 아이콘 대체 텍스트 -->
+              <span>T/O</span>
+            </div>
+            <div class="detail-info">
+              <h3 class="dept-name">{{ detail.department }}</h3>
+              <p class="grade-target">{{ detail.grade }} 승진 대상</p>
+              <div class="stats">
+                <span class="stat-item">배정 T/O <strong>{{ detail.quotaCount }}명</strong></span>
+                <span class="divider">|</span>
+                <span class="stat-item">후보자 {{ detail.candidateList?.length || 0 }}명</span>
+              </div>
+            </div>
+            <div class="hover-arrow">→</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- STEP 3: 부서원(후보자) 추천 -->
+      <div v-if="step === 3 && selectedDetail" class="step-wrapper fade-in">
+        <div class="section-header">
+          <div>
+            <h2>{{ selectedDetail.department }} - {{ selectedDetail.grade }} 승진 후보자</h2>
+            <p class="sub-desc">승진 적격자를 선택하여 추천해주세요.</p>
+          </div>
+        </div>
+
+        <div v-if="!selectedDetail.candidateList?.length" class="no-data">
+          <p>해당 그룹에 추천 가능한 후보자가 없습니다.</p>
+        </div>
+
+        <div class="member-list-grid">
+          <div 
+            v-for="candidate in selectedDetail.candidateList" 
+            :key="candidate.candidateId"
+            class="member-card"
+            :class="{ 'nominated': candidate.isNominated }"
+          >
+            <div class="member-header">
+              <div class="avatar">{{ candidate.employeeName?.charAt(0) || '?' }}</div>
+              <div class="member-id">
+                <span class="name">{{ candidate.employeeName || '이름 없음' }}</span>
+                <span class="pos">{{ candidate.grade }}</span>
+              </div>
+            </div>
+            
+            <div class="member-stats">
+              <div class="stat-row">
+                <span class="label">부서</span>
+                <span class="val">{{ candidate.department }}</span>
+              </div>
+              <div class="stat-row">
+                <span class="label">직급</span>
+                <span class="val">{{ candidate.grade }}</span>
+              </div>
+              <div class="stat-row">
+                <span class="label">사번</span>
+                <span class="val">{{ candidate.employeeNumber }}</span>
+              </div>
+              <div class="stat-row" v-if="candidate.evaluationPoint !== undefined">
+                <span class="label">평가점수</span>
+                <span class="val">{{ candidate.evaluationPoint }}점</span>
+              </div>
+              <div class="stat-row" v-if="candidate.isNominated && candidate.nominatorName">
+                <span class="label">추천자</span>
+                <span class="val">{{ candidate.nominatorName }}</span>
+              </div>
+              <div class="stat-row" v-if="candidate.isNominated && candidate.nominationReason">
+                <span class="label">추천사유</span>
+                <span class="val">{{ candidate.nominationReason }}</span>
+              </div>
+              <div class="stat-row" v-if="candidate.rejectionReason">
+                <span class="label">반려사유</span>
+                <span class="val">{{ candidate.rejectionReason }}</span>
+              </div>
+            </div>
+
+            <div class="extra-actions">
+                <button class="btn-extra">근태 관련</button>
+                <button class="btn-extra">평가 관련</button>
+            </div>
+
+            <div class="member-action">
+              <button 
+                v-if="!candidate.isNominated"
+                class="btn-recommend"
+                @click.stop="startNomination(candidate)"
+              >
+                추천하기
+              </button>
+              <button 
+                v-else
+                class="btn-cancel"
+                @click.stop="cancelCandidateNomination(candidate)"
+              >
+                추천 취소
+              </button>
+            </div>
+
+            <!-- 추천 사유 입력 폼 (인라인) -->
+            <div v-if="activeNominationCandidateId === candidate.candidateId" class="nomination-form fade-in">
+              <textarea
+                v-model="nominationReasonInput"
+                class="reason-textarea"
+                placeholder="추천 사유를 작성해주세요."
+                @click.stop
+              ></textarea>
+              <div class="form-actions">
+                <button class="btn-form-cancel" @click.stop="cancelActiveNomination">취소</button>
+                <button class="btn-form-confirm" @click.stop="confirmNomination(candidate)">추천 완료</button>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { storeToRefs } from 'pinia';
+import { usePromotionRecommendStore } from '@/stores/personnel/promotionRecommend.store';
+import type { PromotionPlanResponseDTO } from '@/types/personnel/promotion.types';
+
+const store = usePromotionRecommendStore();
+const { recommendPlans, recommendPlanDetail, loading } = storeToRefs(store);
+
+// --- State ---
+const step = ref(1);
+const selectedPlan = ref<PromotionPlanResponseDTO | null>(null);
+const selectedDetail = ref<any | null>(null); // 상세 그룹 정보
+
+// --- Inline Form State ---
+const activeNominationCandidateId = ref<number | null>(null);
+const nominationReasonInput = ref('');
+
+// --- Methods ---
+
+const formatDate = (dateStr?: string) => {
+  if (!dateStr) return '-';
+  return dateStr.split('T')[0];
+};
+
+// Step 1 -> Step 2
+const handleSelectPlan = async (plan: PromotionPlanResponseDTO) => {
+  selectedPlan.value = plan;
+  if (plan.promotionId) {
+    await store.getRecommendDetail(plan.promotionId);
+    step.value = 2;
+  }
+};
+
+// Step 2 -> Step 3
+const handleSelectDetail = (detail: any) => {
+  console.log('View: 선택된 상세 그룹:', detail);
+  console.log('View: 후보자 데이터 예시:', detail.candidateList?.[0]);
+  selectedDetail.value = detail;
+  step.value = 3;
+};
+
+// 추천 사유 입력 폼 열기
+const startNomination = (candidate: any) => {
+  activeNominationCandidateId.value = candidate.candidateId;
+  nominationReasonInput.value = '';
+};
+
+// 추천 사유 입력 폼 닫기
+const cancelActiveNomination = () => {
+  activeNominationCandidateId.value = null;
+  nominationReasonInput.value = '';
+};
+
+// 추천 확정 (인라인 폼에서 확인 버튼 클릭 시)
+const confirmNomination = async (candidate: any) => {
+  if (!selectedPlan.value || !selectedPlan.value.promotionId) return;
+
+  if (!nominationReasonInput.value.trim()) {
+    alert('추천 사유를 입력해주세요.');
+    return;
+  }
+
+  const success = await store.requestNomination({
+    promotionId: selectedPlan.value.promotionId,
+    candidateId: candidate.candidateId,
+    nominationReason: nominationReasonInput.value
+  });
+  
+  if (success) {
+    candidate.isNominated = true;
+    // API가 추천자 이름과 사유를 바로 반환하지 않는 경우를 대비하여 프론트에서 채워줌
+    candidate.nominationReason = nominationReasonInput.value;
+    // 추천자 이름은 현재 로그인한 사용자 정보로 채워야 하지만, 해당 정보가 없으므로 임시 처리
+    // candidate.nominatorName = '나'; 
+    alert(`${candidate.employeeName || '후보자'} 님을 추천하였습니다.`);
+    cancelActiveNomination(); // 입력 폼 닫기
+  } else {
+    alert('추천 처리에 실패했습니다.');
+  }
+};
+
+// 추천 취소
+const cancelCandidateNomination = async (candidate: any) => {
+  if (!selectedPlan.value || !selectedPlan.value.promotionId) return;
+
+  if (!confirm(`${candidate.employeeName || '후보자'} 님의 추천을 취소하시겠습니까?`)) return;
+  
+  const success = await store.requestCancelNomination(candidate.candidateId);
+  if (success) {
+    candidate.isNominated = false;
+    // 추천 취소 시 관련 정보 초기화
+    candidate.nominationReason = null;
+    candidate.nominatorName = null;
+  } else {
+    alert('추천 취소에 실패했습니다.');
+  }
+};
+
+onMounted(() => {
+  store.getRecommendPlans();
+});
+</script>
+
+<style scoped>
+/* Inline Nomination Form Styles */
+.nomination-form {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.reason-textarea {
+  width: 100%;
+  height: 80px;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  resize: none;
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+
+.reason-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.btn-form-cancel, .btn-form-confirm {
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.btn-form-cancel {
+  background: #f1f5f9;
+  color: #475569;
+  border-color: #e2e8f0;
+}
+
+.btn-form-confirm {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+}
+
+.promotion-recommend-container {
+  width: 100%;
+  min-height: 100vh;
+  background-color: #f8fafc;
+}
+
+/* Header */
+.header-section {
+  background: white;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 20px;
+}
+
+.header-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 10px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.content-area {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 30px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  margin-bottom: 40px;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.page-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #94a3b8;
+}
+
+.crumb {
+  cursor: pointer;
+}
+
+.crumb.active {
+  color: #3b82f6;
+  font-weight: 600;
+}
+
+.separator {
+  color: #cbd5e1;
+  font-size: 12px;
+}
+
+.btn-back-icon {
+  background: none;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  cursor: pointer;
+  font-size: 20px;
+  padding: 4px;
+  transition: all 0.2s;
+}
+
+.btn-back-icon:hover {
+  color: #334155;
+}
+
+/* Section Header */
+.section-header {
+  margin-bottom: 24px;
+}
+
+.section-header h2 {
+  font-size: 20px;
+  font-weight: 600;
+  color: #334155;
+  margin-bottom: 4px;
+}
+
+.sub-desc {
+  color: #64748b;
+  font-size: 14px;
+}
+
+/* Card Grid System */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+/* Plan Card (Step 1) */
+.plan-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.plan-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  border-color: #3b82f6;
+}
+
+.card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.status-badge {
+  background: #dbeafe;
+  color: #2563eb;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.date-label {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.card-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 20px;
+  line-height: 1.4;
+}
+
+.card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+}
+
+.info-row .label {
+  color: #64748b;
+}
+
+.info-row .value {
+  color: #334155;
+  font-weight: 500;
+}
+
+.card-action {
+  border-top: 1px solid #f1f5f9;
+  padding-top: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #3b82f6;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+/* Detail Card (Step 2) */
+.plan-content-box {
+  background: #f8fafc;
+  padding: 20px;
+  border-radius: 8px;
+  color: #475569;
+  font-size: 14px;
+  line-height: 1.6;
+  margin-bottom: 30px;
+  border: 1px solid #e2e8f0;
+}
+
+.detail-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.detail-card:hover {
+  border-color: #3b82f6;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.detail-icon {
+  width: 48px;
+  height: 48px;
+  background: #eff6ff;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #3b82f6;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+.detail-info {
+  flex: 1;
+}
+
+.dept-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 4px;
+}
+
+.grade-target {
+  font-size: 13px;
+  color: #64748b;
+  margin-bottom: 8px;
+}
+
+.stats {
+  font-size: 13px;
+  color: #475569;
+}
+
+.stats strong {
+  color: #2563eb;
+}
+
+.divider {
+  margin: 0 8px;
+  color: #cbd5e1;
+}
+
+.hover-arrow {
+  color: #cbd5e1;
+  font-weight: bold;
+  transition: transform 0.2s;
+}
+
+.detail-card:hover .hover-arrow {
+  color: #3b82f6;
+  transform: translateX(4px);
+}
+
+/* Member Card (Step 3) */
+.member-list-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 20px;
+}
+
+.member-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: all 0.2s;
+}
+
+.member-card.nominated {
+  border-color: #3b82f6;
+  background: #eff6ff;
+}
+
+.member-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  background: #e2e8f0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.member-card.nominated .avatar {
+  background: #3b82f6;
+  color: white;
+}
+
+.member-id {
+  display: flex;
+  flex-direction: column;
+}
+
+.member-id .name {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.member-id .pos {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.member-stats {
+  background: #f8fafc;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.member-card.nominated .member-stats {
+  background: white;
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+}
+
+.stat-row .label {
+  color: #94a3b8;
+}
+
+.stat-row .val {
+  color: #475569;
+  font-weight: 500;
+}
+
+.member-action button {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+}
+
+.btn-recommend {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+}
+
+.btn-cancel {
+  background: white;
+  border: 1px solid #ef4444 !important;
+  color: #ef4444;
+}
+
+.btn-cancel:hover {
+  background: #fef2f2;
+}
+
+/* Extra Actions */
+.extra-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-extra {
+  flex: 1;
+  padding: 8px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  color: #475569;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-extra:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+/* Common */
+.no-data {
+  text-align: center;
+  padding: 60px;
+  color: #94a3b8;
+  background: #f8fafc;
+  border-radius: 12px;
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 400px;
+  color: #64748b;
+  gap: 16px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #e2e8f0;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.fade-in {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+</style>

--- a/hero-fe/src/views/settings/Settings.vue
+++ b/hero-fe/src/views/settings/Settings.vue
@@ -61,7 +61,8 @@ onMounted(() => {
 <style scoped>
 .page-container {
   background-color: #f8fafc;
-  height: 100vh;
+  height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## 📋 작업 내용
> 팀장이 본인 팀의 승진 후보자를 확인하고 추천 여부와 사유를 입력하는 전용 화면을 개발했습니다.

- 승진 추천 관련 상태 관리를 위한 전용 Store(`promotionRecommend.store`)를 분리했습니다.
- 사용자가 명확한 흐름에 따라 후보자를 추천할 수 있도록 3단계 UI를 구현했습니다.

## 🔧 작업 상세
> 주요 변경 사항을 구체적으로 작성해주세요.

### 변경된 파일
- `src/views/personnel/recommend/Recommend.vue`
- `src/stores/personnel/promotionRecommend.store.ts`
- `src/stores/personnel/promotion.store.ts`
- `src/api/personnel/promotion.api.ts`
- `src/router/modules/personnel.ts`

### 주요 로직 설명
- **3단계 UI/UX**: 사용자가 '승진 계획 선택 → 상세 그룹(T/O) 선택 → 후보자 추천'의 명확한 흐름을 따라 작업을 수행할 수 있도록 단계별 카드 UI를 구성했습니다. `step` 상태 값을 통해 각 단계를 제어합니다.
- **인라인 추천 폼**: 후보자 카드 하단에 입력 폼이 확장되는 방식을 채택하여, 컨텍스트를 유지한 채로 추천 사유를 입력하고 제출할 수 있도록 구현했습니다.


## 🖼️ 스크린샷 (UI 변경 시)
<img width="1613" height="765" alt="image" src="https://github.com/user-attachments/assets/35ed062a-ef81-4c36-b130-2d5bf33ed9f8" />
<img width="1623" height="775" alt="image" src="https://github.com/user-attachments/assets/aae70638-1b9e-4f34-8deb-c9226c9e4795" />
<img width="1629" height="801" alt="image" src="https://github.com/user-attachments/assets/67f4b04c-62c2-436a-b699-5841a8f83e56" />
<img width="368" height="658" alt="image" src="https://github.com/user-attachments/assets/7837ad27-4ff2-4e61-ae29-4d256b9c115f" />
<img width="775" height="614" alt="image" src="https://github.com/user-attachments/assets/edac765c-d5ed-4716-8f0a-189e58add261" />


## 🤔 리뷰 포인트
- `Recommend.vue`의 3단계 UI 흐름과 상태(`step`) 관리 방식에 대한 피드백 부탁드립니다.

## 🔗 관련 이슈
- Closes #79