### PR TITLE
[Feat] 승진 심사 프로세스 구현 및 테이블 스타일 개선

### DIFF
--- a/hero-fe/src/api/personnel/promotion.api.ts
+++ b/hero-fe/src/api/personnel/promotion.api.ts
@@ -23,10 +23,12 @@ import type {
     //request
     PromotionPlanRequestDTO,
     PromotionNominationRequestDTO,
+    PromotionReviewRequestDTO,
     //response
     PromotionOptionsDTO,
     PromotionPlanResponseDTO,
-    PromotionPlanDetailResponseDTO
+    PromotionPlanDetailResponseDTO,
+    PromotionPlanForReviewResponseDTO
 } from '@/types/personnel/promotion.types';
 
 // API 공통 응답 타입 정의
@@ -34,6 +36,7 @@ export interface ApiResponse<T> {
     success: boolean;
     data: T;
     error?: any;
+    message?: string;
 }
 
 // 페이징 응답 타입 정의
@@ -109,4 +112,35 @@ export const nominateCandidate = (data: PromotionNominationRequestDTO) => {
  */
 export const cancelNomination = (candidateId: number) => {
     return client.delete<ApiResponse<void>>(`/promotion/nominations/${candidateId}`);
+}
+
+/**
+ * (인사팀용) 심사 가능한 승진 계획 목록 조회
+ */
+export const fetchPromotionPlansForReview = () => {
+    return client.get<ApiResponse<PromotionPlanResponseDTO[]>>('/promotion/reviews');
+}
+
+/**
+ * (인사팀용) 심사용 승진 계획 상세 조회
+ * @param promotionId 
+ */
+export const fetchReviewPromotionDetail = (promotionId: number) => {
+    return client.get<ApiResponse<PromotionPlanForReviewResponseDTO>>(`/promotion/review/${promotionId}`);
+}
+
+/**
+ * 승진 후보자 심사 (승인/반려)
+ * @param data 
+ */
+export const reviewCandidate = (data: PromotionReviewRequestDTO) => {
+    return client.post<ApiResponse<void>>('/promotion/review', data);
+}
+
+/**
+ * 최종 승인 처리
+ * @param data 
+ */
+export const confirmFinalApproval = (data: PromotionReviewRequestDTO) => {
+    return client.post<ApiResponse<void>>('/promotion/review/final', data);
 }

--- a/hero-fe/src/router/modules/personnel.ts
+++ b/hero-fe/src/router/modules/personnel.ts
@@ -60,7 +60,15 @@ const personnelRoutes: RouteRecordRaw[] = [
         meta: {
           title: '승진 추천',
         }
-      }
+      },
+      {
+        path: 'review',
+        name: 'promotionReview',
+        component: () => import('@/views/personnel/review/Review.vue'),
+        meta: {
+          title: '승진 심사',
+        }
+      },
     ],
   }
 ];

--- a/hero-fe/src/stores/personnel/promotionRecommend.store.ts
+++ b/hero-fe/src/stores/personnel/promotionRecommend.store.ts
@@ -38,11 +38,15 @@ export const usePromotionRecommendStore = defineStore('promotion-recommend', () 
                 console.log('Store: 추천 계획 목록 수신:', response.data.data);
                 recommendPlans.value = response.data.data;
             } else {
-                console.error('추천 가능 계획 조회 API 실패:', response.data.error);
+                console.error(`추천 가능 계획 조회 API 실패 [${(response.data as any).errorCode}]: ${response.data.message}`);
                 recommendPlans.value = [];
             }
-        } catch (error) {
-            console.error('추천 가능 계획 조회 실패:', error);
+        } catch (error: any) {
+            if (error.response && error.response.data) {
+                console.error(`추천 가능 계획 조회 실패 [${error.response.data.errorCode}]: ${error.response.data.message}`);
+            } else {
+                console.error('추천 가능 계획 조회 실패:', error);
+            }
             recommendPlans.value = [];
         } finally {
             loading.value = false;
@@ -57,11 +61,15 @@ export const usePromotionRecommendStore = defineStore('promotion-recommend', () 
                 console.log('Store: 상세 조회 데이터 수신:', response.data.data);
                 recommendPlanDetail.value = response.data.data;
             } else {
-                console.error('추천 상세 조회 API 실패:', response.data.error);
+                console.error(`추천 상세 조회 API 실패 [${(response.data as any).errorCode}]: ${response.data.message}`);
                 recommendPlanDetail.value = null;
             }
-        } catch (error) {
-            console.error('추천 상세 조회 실패:', error);
+        } catch (error: any) {
+            if (error.response && error.response.data) {
+                console.error(`추천 상세 조회 실패 [${error.response.data.errorCode}]: ${error.response.data.message}`);
+            } else {
+                console.error('추천 상세 조회 실패:', error);
+            }
             recommendPlanDetail.value = null;
         } finally {
             loading.value = false;
@@ -72,9 +80,16 @@ export const usePromotionRecommendStore = defineStore('promotion-recommend', () 
         loading.value = true;
         try {
             const response = await nominateCandidate(data);
+            if (!response.data.success) {
+                console.error(`후보자 추천 API 실패 [${(response.data as any).errorCode}]: ${response.data.message}`);
+            }
             return response.data.success;
-        } catch (error) {
-            console.error('후보자 추천 실패:', error);
+        } catch (error: any) {
+            if (error.response && error.response.data) {
+                console.error(`후보자 추천 실패 [${error.response.data.errorCode}]: ${error.response.data.message}`);
+            } else {
+                console.error('후보자 추천 실패:', error);
+            }
             return false;
         } finally {
             loading.value = false;
@@ -85,9 +100,16 @@ export const usePromotionRecommendStore = defineStore('promotion-recommend', () 
         loading.value = true;
         try {
             const response = await cancelNomination(candidateId);
+            if (!response.data.success) {
+                console.error(`추천 취소 API 실패 [${(response.data as any).errorCode}]: ${response.data.message}`);
+            }
             return response.data.success;
-        } catch (error) {
-            console.error('추천 취소 실패:', error);
+        } catch (error: any) {
+            if (error.response && error.response.data) {
+                console.error(`추천 취소 실패 [${error.response.data.errorCode}]: ${error.response.data.message}`);
+            } else {
+                console.error('추천 취소 실패:', error);
+            }
             return false;
         } finally {
             loading.value = false;

--- a/hero-fe/src/stores/personnel/promotionReview.store.ts
+++ b/hero-fe/src/stores/personnel/promotionReview.store.ts
@@ -1,0 +1,122 @@
+/**
+ * <pre>
+ * File Name   : promotionReview.store.ts
+ * Description : 승진 심사 관련 상태 관리 (Pinia)
+ *               - 인사팀의 승진 후보자 심사(승인/반려) 및 조회 기능 담당
+ *
+ * History
+ * 2025/12/23 - 승건 최초 작성
+ * </pre>
+ *
+ * @author 승건
+ * @version 1.0
+ */
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { fetchReviewPromotionDetail, reviewCandidate, fetchPromotionPlansForReview } from '@/api/personnel/promotion.api';
+import type { PromotionPlanForReviewResponseDTO, PromotionReviewRequestDTO, PromotionPlanResponseDTO } from '@/types/personnel/promotion.types';
+
+export const usePromotionReviewStore = defineStore('promotion-review', () => {
+    const reviewPlans = ref<PromotionPlanResponseDTO[]>([]);
+    const reviewDetail = ref<PromotionPlanForReviewResponseDTO | null>(null);
+    const loading = ref(false);
+
+    // 심사 가능한 계획 목록 조회
+    const getReviewPlans = async () => {
+        loading.value = true;
+        try {
+            const response = await fetchPromotionPlansForReview();
+            if (response.data.success) {
+                reviewPlans.value = response.data.data;
+            } else {
+                console.error(`심사 목록 조회 실패: ${response.data.message}`);
+                reviewPlans.value = [];
+            }
+        } catch (error) {
+            console.error('심사 목록 조회 에러:', error);
+            reviewPlans.value = [];
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    // 심사 상세 정보 조회
+    const getReviewDetail = async (id: number) => {
+        loading.value = true;
+        try {
+            const response = await fetchReviewPromotionDetail(id);
+            if (response.data.success) {
+                console.log('Store: 심사 상세 데이터 수신:', response.data.data);
+                reviewDetail.value = response.data.data;
+            } else {
+                console.error(`심사 상세 조회 API 실패 [${(response.data as any).errorCode}]: ${response.data.message}`);
+                reviewDetail.value = null;
+            }
+        } catch (error: any) {
+            if (error.response && error.response.data) {
+                console.error(`심사 상세 조회 실패 [${error.response.data.errorCode}]: ${error.response.data.message}`);
+            } else {
+                console.error('심사 상세 조회 실패:', error);
+            }
+            reviewDetail.value = null;
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    // 후보자 심사 (승인/반려)
+    const submitReview = async (data: PromotionReviewRequestDTO) => {
+        loading.value = true;
+        try {
+            const response = await reviewCandidate(data);
+            if (response.data.success) {
+                // 성공 시 현재 로컬 데이터 업데이트 (재조회 없이 UI 반영)
+                // 백엔드 상태값과 일치시키기 위해 REVIEW_PASSED / REVIEW_REJECTED 사용
+                const status = data.isPassed ? 'REVIEW_PASSED' : 'REVIEW_REJECTED';
+                updateLocalCandidateStatus(data.candidateId, status, data.comment);
+                return true;
+            } else {
+                console.error(`심사 처리 실패 [${(response.data as any).errorCode}]: ${response.data.message}`);
+                return false;
+            }
+        } catch (error: any) {
+            console.error('심사 처리 에러:', error);
+            return false;
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    // 로컬 상태 업데이트 헬퍼
+    const updateLocalCandidateStatus = (candidateId: number, status: string, reason?: string) => {
+        if (!reviewDetail.value) return;
+        
+        reviewDetail.value.detailPlan.forEach(detail => {
+            const candidate = detail.candidateList.find(c => c.candidateId === candidateId);
+            if (candidate) {
+                // 승인 상태 여부 확인 (기존 상태 vs 새로운 상태)
+                const isPreviouslyApproved = ['APPROVED', '1', 'REVIEW_PASSED'].includes(candidate.status || '');
+                const isNowApproved = ['APPROVED', '1', 'REVIEW_PASSED'].includes(status);
+
+                // 상태 변경에 따른 TO(approvedCount) 업데이트
+                if (!isPreviouslyApproved && isNowApproved) {
+                    detail.approvedCount = (detail.approvedCount || 0) + 1;
+                } else if (isPreviouslyApproved && !isNowApproved) {
+                    detail.approvedCount = Math.max(0, (detail.approvedCount || 0) - 1);
+                }
+
+                candidate.status = status;
+                if (reason) candidate.rejectionReason = reason;
+            }
+        });
+    };
+
+    return {
+        reviewPlans,
+        reviewDetail,
+        loading,
+        getReviewPlans,
+        getReviewDetail,
+        submitReview
+    };
+});

--- a/hero-fe/src/stores/personnel/promotionReview.store.ts
+++ b/hero-fe/src/stores/personnel/promotionReview.store.ts
@@ -106,7 +106,9 @@ export const usePromotionReviewStore = defineStore('promotion-review', () => {
                 }
 
                 candidate.status = status;
-                if (reason) candidate.rejectionReason = reason;
+                if (reason) {
+                    candidate.rejectionReason = reason;
+                }
             }
         });
     };

--- a/hero-fe/src/types/personnel/promotion.types.ts
+++ b/hero-fe/src/types/personnel/promotion.types.ts
@@ -45,7 +45,7 @@ export interface PromotionCandidateDTO {
     nominatorName?: string,
     nominationReason?: string,
     status?: string,
-    rejectionReason?: string
+    rejectionReason?: string, // 반려 사유 또는 승인 코멘트
     evaluationPoint?: number
 }
 

--- a/hero-fe/src/types/personnel/promotion.types.ts
+++ b/hero-fe/src/types/personnel/promotion.types.ts
@@ -44,7 +44,7 @@ export interface PromotionCandidateDTO {
     grade?: string,
     nominatorName?: string,
     nominationReason?: string,
-    isApproved?: boolean,
+    status?: string,
     rejectionReason?: string
     evaluationPoint?: number
 }
@@ -85,6 +85,15 @@ export interface PromotionNominationRequestDTO {
     nominationReason: string;
 }
 
+/**
+ * 승진 심사(승인/반려) 요청 DTO
+ */
+export interface PromotionReviewRequestDTO {
+    candidateId: number;
+    isPassed: boolean;
+    comment?: string;
+}
+
 // --- Response DTOs (응답 데이터) ---
 /**
  * 설정할 수 있는 부서, 직급을 알기 위한 옵션 조회용 DTO
@@ -116,4 +125,31 @@ export interface PromotionPlanDetailResponseDTO {
     appointmentAt?: string,
     detailPlan?: PromotionDetailPlanDTO[],
     planContent?: string
+}
+
+/**
+ * 심사용 승진 상세 계획 DTO (승인 현황 포함)
+ */
+export interface PromotionDetailForReviewResponseDTO {
+    promotionDetailId: number;
+    departmentId: number;
+    department: string;
+    gradeId: number;
+    grade: string;
+    quotaCount: number;
+    approvedCount: number;
+    candidateList: PromotionCandidateDTO[];
+}
+
+/**
+ * 심사용 승진 계획 상세 조회 응답 DTO
+ */
+export interface PromotionPlanForReviewResponseDTO {
+    promotionId: number;
+    planName: string;
+    createdAt: string;
+    nominationDeadlineAt: string;
+    appointmentAt: string;
+    planContent: string;
+    detailPlan: PromotionDetailForReviewResponseDTO[];
 }

--- a/hero-fe/src/views/personnel/EmployeeList.vue
+++ b/hero-fe/src/views/personnel/EmployeeList.vue
@@ -271,7 +271,7 @@ onMounted(() => {
 }
 
 .content {
-  padding: 20px;
+  padding: 0;
   border-top: 1px solid #e2e8f0;
 }
 

--- a/hero-fe/src/views/personnel/promotion/CandidateListModal.vue
+++ b/hero-fe/src/views/personnel/promotion/CandidateListModal.vue
@@ -82,9 +82,10 @@ const truncate = (text?: string, length = 15) => {
 const getStatusText = (status?: string) => {
   if (!status) return '-';
   switch (status) {
-    case '0': case 'WAITING': return '대기';
-    case '1': case 'APPROVED': return '승인';
-    case '2': case 'REJECTED': return '반려';
+    case 'WAITING': return '대기';
+    case 'REVIEW_PASSED': return '승인';
+    case 'FINAL_APPROVED': return '최종 승인';
+    case 'REJECTED': return '반려';
     default: return status;
   }
 };
@@ -92,9 +93,10 @@ const getStatusText = (status?: string) => {
 // 상태별 CSS 클래스 매핑
 const getStatusClass = (status?: string) => {
   switch (status) {
-    case '0': case 'WAITING': return 'status-pending';
-    case '1': case 'APPROVED': return 'status-approved';
-    case '2': case 'REJECTED': return 'status-rejected';
+    case 'WAITING': return 'status-pending';
+    case 'REVIEW_PASSED': return 'status-approved';
+    case 'FINAL_APPROVED': return 'status-approved';
+    case 'REJECTED': return 'status-rejected';
     default: return '';
   }
 };

--- a/hero-fe/src/views/personnel/promotion/CandidateListModal.vue
+++ b/hero-fe/src/views/personnel/promotion/CandidateListModal.vue
@@ -1,19 +1,13 @@
-<!-- 
-  File Name   : CandidateListModal.vue
-  Description : 승진 계획 상세의 후보자 목록을 보여주는 모달
-  
-  History
-  2025/12/19 - [User] 최초 작성
--->
 <template>
-  <div v-if="open" class="modal-backdrop" @click.self="closeModal">
+  <div v-if="open" class="modal-overlay" @click.self="close">
     <div class="modal-content">
       <div class="modal-header">
-        <h3 class="modal-title">승진 후보자 목록</h3>
-        <button @click="closeModal" class="close-btn">&times;</button>
+        <h3>승진 후보자 목록</h3>
+        <button class="close-btn" @click="close">×</button>
       </div>
+
       <div class="modal-body">
-        <div class="table-wrapper">
+        <div class="table-container">
           <table class="candidate-table">
             <thead>
               <tr>
@@ -23,23 +17,39 @@
                 <th>직급</th>
                 <th>추천인</th>
                 <th>추천 사유</th>
+                <th>상태</th>
+                <th>비고(반려사유)</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="candidate in candidates" :key="candidate.employeeId">
+              <tr v-for="candidate in candidates" :key="candidate.candidateId">
                 <td>{{ candidate.employeeNumber }}</td>
                 <td>{{ candidate.employeeName }}</td>
                 <td>{{ candidate.department }}</td>
                 <td>{{ candidate.grade }}</td>
                 <td>{{ candidate.nominatorName || '-' }}</td>
-                <td class="reason-cell">{{ candidate.nominationReason || '-' }}</td>
+                <td class="text-left" :title="candidate.nominationReason">
+                  {{ truncate(candidate.nominationReason) }}
+                </td>
+                <td>
+                  <span :class="['status-badge', getStatusClass(candidate.status)]">
+                    {{ getStatusText(candidate.status) }}
+                  </span>
+                </td>
+                <td class="text-left" :title="candidate.rejectionReason">
+                  {{ truncate(candidate.rejectionReason) || '-' }}
+                </td>
               </tr>
               <tr v-if="!candidates || candidates.length === 0">
-                <td colspan="6" class="no-data">등록된 후보자가 없습니다.</td>
+                <td colspan="8" class="no-data">등록된 후보자가 없습니다.</td>
               </tr>
             </tbody>
           </table>
         </div>
+      </div>
+
+      <div class="modal-footer">
+        <button class="btn-confirm" @click="close">확인</button>
       </div>
     </div>
   </div>
@@ -48,27 +58,56 @@
 <script setup lang="ts">
 import type { PromotionCandidateDTO } from '@/types/personnel/promotion.types';
 
-interface Props {
+// Props 정의
+const props = defineProps<{
   open: boolean;
-  candidates: PromotionCandidateDTO[] | undefined;
-}
+  candidates?: PromotionCandidateDTO[];
+}>();
 
-defineProps<Props>();
+// Emits 정의
 const emit = defineEmits(['update:open']);
 
-const closeModal = () => {
+// 모달 닫기
+const close = () => {
   emit('update:open', false);
+};
+
+// 텍스트 말줄임 처리
+const truncate = (text?: string, length = 15) => {
+  if (!text) return '';
+  return text.length > length ? text.substring(0, length) + '...' : text;
+};
+
+// 상태 텍스트 매핑
+const getStatusText = (status?: string) => {
+  if (!status) return '-';
+  switch (status) {
+    case '0': case 'WAITING': return '대기';
+    case '1': case 'APPROVED': return '승인';
+    case '2': case 'REJECTED': return '반려';
+    default: return status;
+  }
+};
+
+// 상태별 CSS 클래스 매핑
+const getStatusClass = (status?: string) => {
+  switch (status) {
+    case '0': case 'WAITING': return 'status-pending';
+    case '1': case 'APPROVED': return 'status-approved';
+    case '2': case 'REJECTED': return 'status-rejected';
+    default: return '';
+  }
 };
 </script>
 
 <style scoped>
-.modal-backdrop {
+.modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -78,71 +117,113 @@ const closeModal = () => {
 .modal-content {
   background: white;
   border-radius: 12px;
-  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
-  width: 90%;
-  max-width: 800px;
+  width: 1000px;
+  max-width: 95%;
+  max-height: 80vh;
   display: flex;
   flex-direction: column;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
 }
 
 .modal-header {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  padding: 16px 24px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 24px;
-  border-bottom: 1px solid #e2e8f0;
+  color: white;
 }
 
-.modal-title {
-  font-size: 18px;
-  font-weight: 600;
-  color: #1c398e;
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: white;
 }
 
 .close-btn {
   background: none;
   border: none;
-  font-size: 24px;
+  font-size: 1.8rem;
   cursor: pointer;
-  color: #94a3b8;
+  color: white;
+  line-height: 1;
 }
 
 .modal-body {
   padding: 24px;
-  max-height: 60vh;
   overflow-y: auto;
+  flex: 1;
+}
+
+.table-container {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow-x: auto;
 }
 
 .candidate-table {
   width: 100%;
   border-collapse: collapse;
-  text-align: left;
-}
-
-.candidate-table th, .candidate-table td {
-  padding: 12px 16px;
-  border-bottom: 1px solid #e2e8f0;
-  font-size: 14px;
 }
 
 .candidate-table th {
-  background-color: #f8fafc;
+  background: #f8fafc;
+  padding: 12px;
   font-weight: 600;
   color: #475569;
+  border-bottom: 1px solid #e2e8f0;
+  white-space: nowrap;
+  font-size: 14px;
 }
 
 .candidate-table td {
+  padding: 12px;
   color: #334155;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: center;
+  font-size: 14px;
 }
 
-.reason-cell {
-  white-space: pre-wrap;
-  word-break: keep-all;
+.text-left {
+  text-align: left !important;
 }
+
+.status-badge {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.status-pending { background-color: #f1f5f9; color: #64748b; }
+.status-approved { background-color: #dcfce7; color: #166534; }
+.status-rejected { background-color: #fee2e2; color: #991b1b; }
 
 .no-data {
-  text-align: center;
-  padding: 40px;
+  padding: 40px !important;
   color: #94a3b8;
+}
+
+.modal-footer {
+  padding: 16px 24px;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn-confirm {
+  background: #1c398e;
+  color: white;
+  border: none;
+  padding: 10px 30px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.btn-confirm:hover {
+  background: #162456;
 }
 </style>

--- a/hero-fe/src/views/personnel/promotion/PromotionPlan.vue
+++ b/hero-fe/src/views/personnel/promotion/PromotionPlan.vue
@@ -218,8 +218,9 @@ onMounted(() => {
 }
 
 .content {
-  padding: 20px 20px 0;
+  padding: 0;
   flex: 1;
+  overflow: auto;
 }
 
 .promotion-table {

--- a/hero-fe/src/views/personnel/recommend/Recommend.vue
+++ b/hero-fe/src/views/personnel/recommend/Recommend.vue
@@ -246,8 +246,13 @@ const handleSelectPlan = async (plan: PromotionPlanResponseDTO) => {
 
 // Step 2 -> Step 3
 const handleSelectDetail = (detail: any) => {
-  console.log('View: 선택된 상세 그룹:', detail);
-  console.log('View: 후보자 데이터 예시:', detail.candidateList?.[0]);
+  console.group('상세 그룹 및 후보자 데이터 확인');
+  console.log('선택된 상세 그룹:', detail);
+  if (detail.candidateList && detail.candidateList.length > 0) {
+    console.log('첫 번째 후보자 데이터:', detail.candidateList[0]);
+    console.log('첫 번째 후보자의 추천 사유(nominationReason):', detail.candidateList[0].nominationReason);
+  }
+  console.groupEnd();
   selectedDetail.value = detail;
   step.value = 3;
 };
@@ -710,16 +715,23 @@ onMounted(() => {
 .stat-row {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   font-size: 13px;
+  gap: 8px;
 }
 
 .stat-row .label {
   color: #94a3b8;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .stat-row .val {
   color: #475569;
   font-weight: 500;
+  text-align: right;
+  word-break: break-word;
+  white-space: pre-wrap;
 }
 
 .member-action button {

--- a/hero-fe/src/views/personnel/review/Review.vue
+++ b/hero-fe/src/views/personnel/review/Review.vue
@@ -1,0 +1,940 @@
+<template>
+  <div class="review-page-container">
+    <!-- 헤더 영역 -->
+    <div class="header-section">
+      <div class="header-inner">
+        <div class="header-left">
+          <button v-if="step > 1" class="btn-back-icon" @click="step--">←</button>
+          <h1 class="page-title">승진 심사</h1>
+        </div>
+        
+        <!-- 단계 표시 (Breadcrumbs) -->
+        <div class="breadcrumbs" v-if="step > 1">
+          <span class="crumb" :class="{ active: step === 1 }" @click="step = 1">계획 선택</span>
+          <span class="separator">›</span>
+          <span class="crumb" :class="{ active: step === 2 }" @click="step > 2 ? step = 2 : null">심사 대상</span>
+          <span class="separator">›</span>
+          <span class="crumb" :class="{ active: step === 3 }">후보자 심사</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- 로딩 상태 -->
+    <div v-if="reviewStore.loading" class="loading-state">
+      <div class="spinner"></div>
+      <p>데이터를 불러오는 중입니다...</p>
+    </div>
+
+    <!-- 메인 컨텐츠 영역 -->
+    <div v-else class="content-area">
+
+      <!-- STEP 1: 심사 대상 계획 목록 -->
+      <div v-if="step === 1" class="step-wrapper fade-in">
+        <div class="section-header">
+          <h2>심사 대상 계획</h2>
+          <p class="sub-desc">심사를 진행할 승진 계획을 선택해주세요.</p>
+        </div>
+
+        <div v-if="!reviewStore.reviewPlans.length" class="no-data">
+          <p>진행중인 계획이 없습니다.</p>
+        </div>
+
+        <div class="card-grid">
+          <div
+            v-for="plan in reviewStore.reviewPlans"
+            :key="plan.promotionId"
+            class="plan-card"
+            @click="handleSelectPlan(plan.promotionId!)"
+          >
+             <div class="card-top">
+              <span class="status-badge">진행중</span>
+              <span class="date-label">{{ formatDate(plan.createdAt) }} 등록</span>
+            </div>
+            <h3 class="card-title">{{ plan.planName }}</h3>
+            <div class="card-info">
+              <div class="info-row">
+                <span class="label">추천 마감</span>
+                <span class="value">{{ formatDate(plan.nominationDeadlineAt) }}</span>
+              </div>
+              <div class="info-row">
+                <span class="label">발령 예정</span>
+                <span class="value">{{ formatDate(plan.appointmentAt) }}</span>
+              </div>
+            </div>
+            <div class="card-action">
+              <span>심사하기</span>
+              <span class="arrow">→</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- STEP 2: 계획 상세 및 심사 대상 그룹 선택 -->
+      <div v-if="step === 2 && reviewStore.reviewDetail" class="step-wrapper fade-in">
+        <div class="section-header">
+          <div>
+            <h2>{{ reviewStore.reviewDetail.planName }}</h2>
+            <p class="sub-desc">심사를 진행할 대상 그룹(부서/직급)을 선택해주세요.</p>
+          </div>
+        </div>
+
+        <div class="plan-content-box">
+           {{ reviewStore.reviewDetail.planContent || '상세 내용이 없습니다.' }}
+        </div>
+
+        <div class="card-grid detail-grid">
+          <div
+            v-for="detail in reviewStore.reviewDetail.detailPlan"
+            :key="detail.promotionDetailId"
+            class="detail-card"
+            @click="handleSelectDetailPlan(detail)"
+          >
+            <div class="detail-icon">
+              <span>T/O</span>
+            </div>
+            <div class="detail-info">
+              <h3 class="dept-name">{{ detail.department }}</h3>
+              <p class="grade-target">{{ detail.grade }} 승진 심사</p>
+              <div class="stats">
+                <span class="stat-item">TO: <strong>{{ detail.approvedCount }} / {{ detail.quotaCount }}</strong></span>
+                <span class="divider">|</span>
+                <span class="stat-item">후보자 {{ detail.candidateList.length }}명</span>
+              </div>
+            </div>
+            <div class="hover-arrow">→</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- STEP 3: 후보자 심사 -->
+      <div v-if="step === 3 && selectedDetailPlan" class="step-wrapper fade-in">
+        <div class="section-header">
+          <div>
+            <h2>{{ selectedDetailPlan.department }} - {{ selectedDetailPlan.grade }} 심사 후보자</h2>
+            <p class="sub-desc">승진 적격 여부를 심사해주세요.</p>
+          </div>
+        </div>
+
+        <div v-if="!selectedDetailPlan.candidateList.length" class="no-data">
+            후보자가 없습니다.
+        </div>
+
+        <div class="member-list-grid">
+          <div v-for="candidate in selectedDetailPlan.candidateList" :key="candidate.candidateId" class="member-card" :class="getStatusClass(candidate.status)">
+            <template v-if="editingId !== candidate.candidateId">
+            <div class="member-header">
+              <div class="avatar">{{ candidate.employeeName?.charAt(0) || '?' }}</div>
+              <div class="member-id">
+                <span class="name">{{ candidate.employeeName }} ({{ candidate.employeeNumber }})</span>
+                <span class="pos">{{ candidate.grade }}</span>
+              </div>
+              <div class="status-badge-small" :class="getStatusClass(candidate.status)">
+                {{ getStatusText(candidate.status) }}
+              </div>
+            </div>
+
+            <div class="member-stats">
+               <div class="stat-row">
+                <span class="label">부서</span>
+                <span class="val">{{ candidate.department }}</span>
+              </div>
+              <div class="stat-row" v-if="candidate.evaluationPoint !== undefined">
+                <span class="label">평가점수</span>
+                <span class="val">{{ candidate.evaluationPoint }}점</span>
+              </div>
+               <div class="stat-row" v-if="candidate.nominatorName">
+                <span class="label">추천자</span>
+                <span class="val">{{ candidate.nominatorName }}</span>
+              </div>
+              <div class="stat-row" v-if="candidate.nominationReason">
+                <span class="label">추천사유</span>
+                <span class="val">{{ candidate.nominationReason }}</span>
+              </div>
+               <div class="stat-row" v-if="candidate.rejectionReason">
+                <span class="label">{{ getReasonLabel(candidate) }}</span>
+                <span class="val">{{ candidate.rejectionReason }}</span>
+              </div>
+            </div>
+
+            <div class="extra-actions">
+              <button class="btn-extra" disabled title="기능 준비중입니다.">평가 상세</button>
+              <button class="btn-extra" disabled title="기능 준비중입니다.">근태 상세</button>
+            </div>
+
+            <div class="member-action" v-if="!isReviewed(candidate)">
+              <button @click="startReview(candidate, 'APPROVED')" class="btn-approve">승인</button>
+              <button @click="startReview(candidate, 'REJECTED')" class="btn-reject">반려</button>
+            </div>
+            </template>
+
+            <!-- 수정 모드 (코멘트 입력) -->
+            <template v-else>
+              <div class="member-header">
+                <div class="avatar">{{ candidate.employeeName?.charAt(0) || '?' }}</div>
+                <div class="member-id">
+                  <span class="name">{{ candidate.employeeName }}</span>
+                  <span class="pos">{{ editAction === 'APPROVED' ? '승인 심사' : '반려 심사' }}</span>
+                </div>
+              </div>
+              <div class="edit-box">
+                <p class="edit-guide">{{ editAction === 'APPROVED' ? '승인 코멘트(선택)' : '반려 사유(필수)' }}를 입력하세요.</p>
+                <textarea v-model="editComment" class="review-input" rows="3" placeholder="내용을 입력해주세요."></textarea>
+                <div class="edit-actions">
+                  <button @click="confirmReview" class="btn-confirm">확인</button>
+                  <button @click="cancelReview" class="btn-cancel">취소</button>
+                </div>
+              </div>
+            </template>
+          </div>
+        </div>
+
+        <!-- 전자 결재 상신 버튼 영역 -->
+        <div class="step-footer">
+          <div class="footer-info">
+            <p>심사가 완료되었나요?</p>
+            <span>전자 결재를 상신하여 최종 승인 절차를 진행하세요.</span>
+          </div>
+          <button class="btn-electronic-approval" @click="handleElectronicApproval" disabled title="기능 준비중입니다.">
+            📑 전자 결재 상신 (준비중)
+          </button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { usePromotionReviewStore } from '@/stores/personnel/promotionReview.store';
+import type { PromotionDetailForReviewResponseDTO, PromotionCandidateDTO, PromotionReviewRequestDTO } from '@/types/personnel/promotion.types';
+
+const router = useRouter();
+const reviewStore = usePromotionReviewStore();
+
+// 심사 입력 상태 관리
+const editingId = ref<number | null>(null);
+const editAction = ref<'APPROVED' | 'REJECTED' | null>(null);
+const editComment = ref('');
+
+const step = ref(1);
+const selectedPlanId = ref<number | null>(null);
+const selectedDetailPlan = ref<PromotionDetailForReviewResponseDTO | null>(null);
+
+onMounted(() => {
+  // 심사 가능한 계획 목록 조회
+  reviewStore.getReviewPlans();
+});
+
+const formatDate = (dateStr?: string) => {
+  if (!dateStr) return '-';
+  return dateStr.split('T')[0];
+};
+
+const handleSelectPlan = async (planId: number) => {
+  selectedPlanId.value = planId;
+  await reviewStore.getReviewDetail(planId);
+  step.value = 2;
+};
+
+const handleSelectDetailPlan = (detailPlan: PromotionDetailForReviewResponseDTO) => {
+  selectedDetailPlan.value = detailPlan;
+  step.value = 3;
+};
+
+// 상태값 매핑 (CandidateListModal.vue 와 동일한 로직)
+const getStatusText = (status?: string) => {
+  if (!status) return '대기';
+  switch (status) {
+    case '0': case 'WAITING': return '대기';
+    case '1': case 'APPROVED': case 'REVIEW_PASSED': return '승인';
+    case '2': case 'REJECTED': case 'REVIEW_REJECTED': return '반려';
+    case 'FINAL_APPROVED': return '최종 승인';
+    default: return status;
+  }
+};
+
+const getStatusClass = (status?: string) => {
+  switch (status) {
+    case '1': case 'APPROVED': case 'REVIEW_PASSED': return 'status-approved';
+    case '2': case 'REJECTED': case 'REVIEW_REJECTED': return 'status-rejected';
+    case 'FINAL_APPROVED': return 'status-final-approved';
+    default: return 'status-pending';
+  }
+};
+
+const startReview = (candidate: PromotionCandidateDTO, action: 'APPROVED' | 'REJECTED') => {
+  if (!candidate.candidateId) return;
+
+  // 승인 시 TO(정원) 체크
+  if (action === 'APPROVED' && selectedDetailPlan.value) {
+    const { approvedCount, quotaCount } = selectedDetailPlan.value;
+    if (approvedCount >= quotaCount) {
+      alert(`해당 그룹의 승진 T/O(${quotaCount}명)가 모두 찼습니다.\n더 이상 승인할 수 없습니다.`);
+      return;
+    }
+  }
+
+  editingId.value = candidate.candidateId;
+  editAction.value = action;
+  editComment.value = '';
+};
+
+const cancelReview = () => {
+  editingId.value = null;
+  editAction.value = null;
+  editComment.value = '';
+};
+
+const confirmReview = async () => {
+  if (!editingId.value || !editAction.value) return;
+
+  const payload: PromotionReviewRequestDTO = {
+    candidateId: editingId.value,
+    isPassed: editAction.value === 'APPROVED',
+    comment: editComment.value
+  };
+
+  const success = await reviewStore.submitReview(payload);
+  if (success) {
+    cancelReview();
+  } else {
+    // 에러 처리는 스토어에서 로깅함. 필요시 토스트 메시지 추가
+    alert('처리 중 오류가 발생했습니다.');
+  }
+};
+
+const isReviewed = (candidate: PromotionCandidateDTO) => {
+  return ['APPROVED', 'REJECTED', '1', '2', 'REVIEW_PASSED', 'REVIEW_REJECTED', 'FINAL_APPROVED'].includes(candidate.status || '');
+};
+
+const getReasonLabel = (candidate: PromotionCandidateDTO) => {
+  const status = candidate.status || '';
+  return (status === 'APPROVED' || status === '1' || status === 'REVIEW_PASSED' || status === 'FINAL_APPROVED') ? '승인코멘트' : '반려사유';
+};
+
+const handleElectronicApproval = () => {
+  if (!selectedDetailPlan.value) return;
+
+  // 미심사 인원 체크 (안내용)
+  const unreviewedCount = selectedDetailPlan.value.candidateList.filter(c => !c.status || c.status === 'WAITING' || c.status === '0').length;
+  
+  let message = '전자 결재를 상신하시겠습니까?';
+  if (unreviewedCount > 0) {
+    message = `아직 심사하지 않은 후보자가 ${unreviewedCount}명 있습니다.\n그래도 결재를 진행하시겠습니까?`;
+  }
+
+  if (confirm(message)) {
+    router.push({
+      path: '/approval/create/personnelappointment',
+      query: {
+        promotionId: selectedPlanId.value?.toString(),
+        detailId: selectedDetailPlan.value.promotionDetailId.toString()
+      }
+    });
+  }
+};
+
+</script>
+
+<style scoped>
+.review-page-container  {
+  width: 100%;
+  min-height: 100vh;
+  background-color: #f8fafc;
+}
+
+/* Header */
+.header-section {
+  background: white;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 20px;
+}
+
+.header-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 10px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.content-area {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 30px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  margin-bottom: 40px;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.page-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #94a3b8;
+}
+
+.crumb {
+  cursor: pointer;
+}
+
+.crumb.active {
+  color: #3b82f6;
+  font-weight: 600;
+}
+
+.separator {
+  color: #cbd5e1;
+  font-size: 12px;
+}
+
+.btn-back-icon {
+  background: none;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  cursor: pointer;
+  font-size: 20px;
+  padding: 4px;
+  transition: all 0.2s;
+}
+
+.btn-back-icon:hover {
+  color: #334155;
+}
+
+/* Section Header */
+.section-header {
+  margin-bottom: 24px;
+}
+
+.section-header h2 {
+  font-size: 20px;
+  font-weight: 600;
+  color: #334155;
+  margin-bottom: 4px;
+}
+
+.sub-desc {
+  color: #64748b;
+  font-size: 14px;
+}
+
+/* Card Grid System */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+/* Plan Card (Step 1) */
+.plan-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.plan-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  border-color: #3b82f6;
+}
+
+.card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.status-badge {
+  background: #dbeafe;
+  color: #2563eb;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.date-label {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.card-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 20px;
+  line-height: 1.4;
+}
+
+.card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+}
+
+.info-row .label {
+  color: #64748b;
+}
+
+.info-row .value {
+  color: #334155;
+  font-weight: 500;
+}
+
+.card-action {
+  border-top: 1px solid #f1f5f9;
+  padding-top: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #3b82f6;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+/* Detail Card (Step 2) */
+.plan-content-box {
+  background: #f8fafc;
+  padding: 20px;
+  border-radius: 8px;
+  color: #475569;
+  font-size: 14px;
+  line-height: 1.6;
+  margin-bottom: 30px;
+  border: 1px solid #e2e8f0;
+}
+
+.detail-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.detail-card:hover {
+  border-color: #3b82f6;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.detail-icon {
+  width: 48px;
+  height: 48px;
+  background: #eff6ff;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #3b82f6;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+.detail-info {
+  flex: 1;
+}
+
+.dept-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 4px;
+}
+
+.grade-target {
+  font-size: 13px;
+  color: #64748b;
+  margin-bottom: 8px;
+}
+
+.stats {
+  font-size: 13px;
+  color: #475569;
+}
+
+.stats strong {
+  color: #2563eb;
+}
+
+.divider {
+  margin: 0 8px;
+  color: #cbd5e1;
+}
+
+.hover-arrow {
+  color: #cbd5e1;
+  font-weight: bold;
+  transition: transform 0.2s;
+}
+
+.detail-card:hover .hover-arrow {
+  color: #3b82f6;
+  transform: translateX(4px);
+}
+
+/* Member Card (Step 3) */
+.member-list-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 20px;
+}
+
+.member-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: all 0.2s;
+}
+
+.member-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  background: #e2e8f0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.member-id {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.member-id .name {
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.member-id .pos {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.status-badge-small {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* 상태 배지 스타일 */
+.status-badge-small.status-pending { background-color: #f1f5f9; color: #64748b; }
+.status-badge-small.status-approved { background-color: #dcfce7; color: #166534; }
+.status-badge-small.status-rejected { background-color: #fee2e2; color: #991b1b; }
+.status-badge-small.status-final-approved { background: linear-gradient(180deg, #1c398e 0%, #162456 100%); color: white; }
+
+/* 카드 상태별 스타일 */
+.member-card.status-pending { border-left: 4px solid #cbd5e1; }
+.member-card.status-approved { background-color: #f0fdf4; border: 1px solid #bbf7d0; border-left: 4px solid #22c55e; }
+.member-card.status-rejected { background-color: #fef2f2; border: 1px solid #fecaca; border-left: 4px solid #ef4444; }
+
+/* 최종 승인 카드 스타일 개선 (가독성 확보) */
+.member-card.status-final-approved {
+  background-color: #eff6ff; /* 아주 연한 파란색 */
+  border: 1px solid #bfdbfe;
+  border-left: 4px solid #1c398e; /* 진한 남색 포인트 */
+  box-shadow: 0 4px 6px -1px rgba(28, 57, 142, 0.1);
+}
+
+.member-stats {
+  background: #f8fafc;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.member-card.status-final-approved .member-stats {
+  background-color: rgba(255, 255, 255, 0.6);
+  border: 1px solid #dbeafe;
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+}
+
+.stat-row .label {
+  color: #94a3b8;
+}
+
+.stat-row .val {
+  color: #475569;
+  font-weight: 500;
+}
+
+.extra-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-extra {
+  flex: 1;
+  padding: 8px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  color: #64748b;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-extra:disabled {
+  background-color: #f8fafc;
+  color: #94a3b8;
+  cursor: not-allowed;
+  border-color: #e2e8f0;
+}
+
+.member-action {
+  display: flex;
+  gap: 10px;
+}
+
+.btn-approve, .btn-reject {
+  flex: 1;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.btn-approve {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.btn-reject {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.no-data {
+  text-align: center;
+  padding: 60px;
+  color: #94a3b8;
+  background: #f8fafc;
+  border-radius: 12px;
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 400px;
+  color: #64748b;
+  gap: 16px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #e2e8f0;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.fade-in {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Edit Mode Styles */
+.edit-box {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px dashed #e2e8f0;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.edit-guide {
+  font-size: 12px;
+  color: #64748b;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.review-input {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  background-color: #f8fafc;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  resize: none;
+  font-size: 14px;
+  color: #334155;
+  font-family: inherit;
+  transition: all 0.2s ease;
+}
+
+.review-input:focus {
+  outline: none;
+  background-color: #ffffff;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.edit-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.btn-confirm {
+  background: #3b82f6;
+  color: white;
+  border: none;
+  padding: 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.btn-confirm:hover {
+  background: #2563eb;
+}
+
+.btn-cancel {
+  background: white;
+  border: 1px solid #e2e8f0;
+  color: #64748b;
+  padding: 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.btn-cancel:hover {
+  background: #f8fafc;
+  color: #334155;
+  border-color: #cbd5e1;
+}
+
+/* Step Footer (Electronic Approval) */
+.step-footer {
+  margin-top: 40px;
+  padding-top: 30px;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.footer-info p {
+  font-size: 16px;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 4px;
+}
+
+.footer-info span {
+  font-size: 14px;
+  color: #64748b;
+}
+
+.btn-electronic-approval {
+  background-color: #1e293b;
+  color: white;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.btn-electronic-approval:hover {
+  background-color: #0f172a;
+  transform: translateY(-2px);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+.btn-electronic-approval:disabled {
+  background-color: #94a3b8;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+</style>

--- a/hero-fe/src/views/personnel/review/Review.vue
+++ b/hero-fe/src/views/personnel/review/Review.vue
@@ -706,16 +706,23 @@ const handleElectronicApproval = () => {
 .stat-row {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   font-size: 13px;
+  gap: 8px;
 }
 
 .stat-row .label {
   color: #94a3b8;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .stat-row .val {
   color: #475569;
   font-weight: 500;
+  text-align: right;
+  word-break: break-word;
+  white-space: pre-wrap;
 }
 
 .extra-actions {

--- a/hero-fe/src/views/settings/Department.vue
+++ b/hero-fe/src/views/settings/Department.vue
@@ -1,7 +1,6 @@
 <template>
-  <div>
+  <div class="page-content">
     <div class="page-header">
-      <h2 class="page-title">부서 관리</h2>
       <button @click="saveDepartments" class="btn-save">
         변경사항 저장
       </button>
@@ -342,9 +341,19 @@ onMounted(async () => {
 <style scoped>
 .page-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   margin-bottom: 20px;
+}
+
+.page-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+  padding: 24px;
+  overflow: hidden;
 }
 
 .page-title {
@@ -382,8 +391,7 @@ onMounted(async () => {
   border: 1px solid #e2e8f0;
   border-radius: 14px;
   padding: 20px;
-  min-height: 400px;
-  max-height: 600px;
+  height: calc(100vh - 300px);
   overflow-y: auto;
 }
 

--- a/hero-fe/src/views/settings/Grade.vue
+++ b/hero-fe/src/views/settings/Grade.vue
@@ -1,7 +1,6 @@
 <template>
-  <div>
+  <div class="page-content">
     <div class="page-header">
-      <h2 class="page-title">직급 관리</h2>
       <button @click="saveGrades" class="btn-save">
         저장
       </button>
@@ -112,8 +111,9 @@ const saveGrades = async () => {
 <style scoped>
 .page-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
+  padding: 24px 24px 0;
   margin-bottom: 20px;
 }
 
@@ -137,11 +137,21 @@ const saveGrades = async () => {
   background-color: #162456;
 }
 
+.page-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .table-container {
   overflow-x: auto;
-  /* overflow-y: auto; */
-  border: 1px solid #e2e8f0;
-  border-radius: 14px;
+  overflow-y: auto;
+  height: calc(100vh - 300px);
+  border-top: 1px solid #e2e8f0;
+  border-bottom: 1px solid #e2e8f0;
+  background: white;
   margin-bottom: 20px;
 }
 
@@ -191,7 +201,8 @@ const saveGrades = async () => {
 }
 
 .btn-add {
-  width: 100%;
+  width: calc(100% - 48px);
+  margin: 0 24px 24px;
   padding: 12px;
   border: 2px dashed #e2e8f0;
   color: #64748b;

--- a/hero-fe/src/views/settings/JobTitle.vue
+++ b/hero-fe/src/views/settings/JobTitle.vue
@@ -1,7 +1,6 @@
 <template>
-  <div>
+  <div class="page-content">
     <div class="page-header">
-      <h2 class="page-title">직책 관리</h2>
       <button @click="saveJobTitles" class="btn-save">
         저장
       </button>
@@ -98,8 +97,9 @@ const saveJobTitles = async () => {
 <style scoped>
 .page-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
+  padding: 24px 24px 0;
   margin-bottom: 20px;
 }
 
@@ -123,11 +123,22 @@ const saveJobTitles = async () => {
   background-color: #162456;
 }
 
+.page-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .table-container {
   overflow-x: auto;
-  /* overflow-y: auto; */
+  overflow-y: auto;
+  height: calc(100vh - 300px);
   border: 1px solid #e2e8f0;
-  border-radius: 14px;
+  border-top: 1px solid #e2e8f0;
+  border-bottom: 1px solid #e2e8f0;
+  background: white;
   margin-bottom: 20px;
 }
 
@@ -178,6 +189,8 @@ const saveJobTitles = async () => {
 
 .btn-add {
   width: 100%;
+  width: calc(100% - 48px);
+  margin: 0 24px 24px;
   padding: 12px;
   border: 2px dashed #e2e8f0;
   color: #64748b;

--- a/hero-fe/src/views/settings/Permission.vue
+++ b/hero-fe/src/views/settings/Permission.vue
@@ -1,9 +1,5 @@
 <template>
-  <div>
-    <div class="page-header">
-      <h2 class="page-title">사원 권한 관리</h2>
-    </div>
-    
+  <div class="page-content">
     <!-- 검색 -->
     <div class="search-container">
       <input v-model="searchQuery" @keyup.enter="fetchData" type="text" placeholder="사원명 검색" class="search-input" />
@@ -263,6 +259,8 @@ onMounted(async () => {
   display: flex;
   gap: 10px;
   margin-bottom: 20px;
+  padding: 24px 24px 0;
+  justify-content: flex-end;
 }
 
 .search-input {
@@ -284,14 +282,23 @@ onMounted(async () => {
   font-weight: 600;
 }
 
+.page-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .data-table tbody tr:last-child td {
   border-bottom: none;
 }
 
 .table-container {
   overflow-x: auto;
+  overflow-y: auto;
+  height: calc(100vh - 300px);
   border: 1px solid #e2e8f0;
-  border-radius: 14px;
   margin-bottom: 20px;
 }
 
@@ -308,6 +315,9 @@ onMounted(async () => {
 }
 
 .data-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
   color: white;
   font-weight: 600;

--- a/hero-fe/src/views/settings/Settings.vue
+++ b/hero-fe/src/views/settings/Settings.vue
@@ -139,8 +139,11 @@ onMounted(() => {
 }
 
 .content-container {
+  padding: 0;
   flex: 1;
-  height: auto;
+  min-height: 0;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 </style>


### PR DESCRIPTION
## 📋 작업 내용

- 승진 심사 페이지(Review.vue) 3단계 진행 UI
- 심사 승인/반려 API 연동을 위한 DTO 및 스토어
- 심사 상태별(승인, 반려, 최종승인) UI 시각화 및 T/O 체크 로직 추가
- 설정 및 인사 관리 메뉴 내 테이블 컴포넌트 레이아웃/스타일 통일

## 🔧 작업 상세

### 변경된 파일
- `src/views/personnel/review/Review.vue`
- `src/stores/personnel/promotionReview.store.ts`
- `src/types/personnel/promotion.types.ts`
- `src/api/personnel/promotion.api.ts`
- `src/views/settings/Settings.vue`
- `src/views/settings/Grade.vue`
- `src/views/settings/JobTitle.vue`
- `src/views/settings/Permission.vue`
- `src/views/settings/Department.vue`
- `src/views/personnel/EmployeeList.vue`
- `src/views/personnel/promotion/PromotionPlan.vue`

### 주요 로직 설명
- **승진 심사 프로세스**:  `계획 선택 -> 상세 그룹 선택 -> 후보자 심사`의 3단계 위자드 형식으로 UI
- **T/O(정원) 체크**: 승인 시 해당 그룹의 승진 정원(`quotaCount`)을 초과하지 않도록 `approvedCount`를 실시간으로 체크하고 제한
- **테이블 스타일 통일**: 설정(`Settings`) 및 인사 관리(`Personnel`) 페이지 내 모든 테이블 컴포넌트의 패딩을 제거하고 모서리 스타일을 수정하여, 메인 카드 영역을 꽉 채우는 일관된 디자인을 적용했습니다.

## 🖼️ 스크린샷 (UI 변경 시)

## 🤔 리뷰 포인트
<img width="1583" height="653" alt="image" src="https://github.com/user-attachments/assets/2dbfd076-1556-4e3d-b9b7-ed751f5ab67a" />
<img width="1600" height="646" alt="image" src="https://github.com/user-attachments/assets/71d09b26-78ec-49b1-92d8-d227f577e242" />
<img width="1526" height="793" alt="image" src="https://github.com/user-attachments/assets/b1ab4410-2c23-44b0-a5c5-3cd7321fbd4b" />
<img width="1547" height="781" alt="image" src="https://github.com/user-attachments/assets/20698254-add7-49e5-996d-159e53935fea" />


## 🔗 관련 이슈
- Closes #80 

## 💬 추가 코멘트
- 
- 전자 결재 상신 버튼은 UI에 추가되었으나, 현재 기능 준비중 상태로 비활성화(`disabled`) 처리되어 있습니다.
- 이 후 '평가 상세'나 '근태 상세' 버튼은 주말 중에 해당 도메인 찾아봐서 적절하게 데이터를 가져오는 것으로 하든 아니면 관련된 페이지로 이동할지는 고민 중입니다. 현재 생각으로는 새롭게 불러와서 모달이나 사이드에서 추가 화면이 올라오게 만들어 보는 방식이 가장 좋을 것 같아 보입니다. 한번의 심사 흐름에서 다른 페이지로 이동하는 것은 UX적으로 좋지 않아 보이기 떄문에 위와 같은 생각을 했습니다.
- 현재 전자 결재 상신 버튼을 만들어는 두었는데 이것은 백엔드 단에서 후보자 상태가 대기->승인 으로 넘어가면 로직으로 누른 사람의 결재 임시 저장함에 담을 수 있게 만드는 것이 어떤가 생각 중입니다.
