### PR TITLE
[Feat] 비밀번호 변경 및 찾기(재설정) 기능 구현

### DIFF
--- a/hero-fe/src/api/auth/password.api.ts
+++ b/hero-fe/src/api/auth/password.api.ts
@@ -1,0 +1,21 @@
+import apiClient from '@/api/apiClient';
+import type { 
+  PasswordChangeRequest, 
+  PasswordResetRequest, 
+  PasswordReset 
+} from '@/types/auth/password.types';
+
+// 비밀번호 변경 (로그인 후)
+export const changePassword = (data: PasswordChangeRequest) => {
+  return apiClient.put('/auth/password', data);
+};
+
+// 비밀번호 재설정 요청 (이메일 발송)
+export const requestPasswordReset = (data: PasswordResetRequest) => {
+  return apiClient.post('/auth/password/reset-request', data);
+};
+
+// 비밀번호 재설정 (토큰 사용)
+export const resetPassword = (data: PasswordReset) => {
+  return apiClient.post('/auth/password/reset', data);
+};

--- a/hero-fe/src/api/auth/password.api.ts
+++ b/hero-fe/src/api/auth/password.api.ts
@@ -7,7 +7,7 @@ import type {
 
 // 비밀번호 변경 (로그인 후)
 export const changePassword = (data: PasswordChangeRequest) => {
-  return apiClient.put('/auth/password', data);
+  return apiClient.put('/employee/password', data);
 };
 
 // 비밀번호 재설정 요청 (이메일 발송)

--- a/hero-fe/src/api/personnel/promotion.api.ts
+++ b/hero-fe/src/api/personnel/promotion.api.ts
@@ -24,6 +24,7 @@ import type {
     PromotionPlanRequestDTO,
     PromotionNominationRequestDTO,
     PromotionReviewRequestDTO,
+    DirectPromotionRequestDTO,
     //response
     PromotionOptionsDTO,
     PromotionPlanResponseDTO,
@@ -143,4 +144,12 @@ export const reviewCandidate = (data: PromotionReviewRequestDTO) => {
  */
 export const confirmFinalApproval = (data: PromotionReviewRequestDTO) => {
     return client.post<ApiResponse<void>>('/promotion/review/final', data);
+}
+
+/**
+ * 특정 직원을 즉시 승진시킵니다. (특별 승진)
+ * @param data 즉시 승진 요청 정보
+ */
+export const promoteDirectly = (data: DirectPromotionRequestDTO) => {
+    return client.post<ApiResponse<void>>('/promotion/direct', data);
 }

--- a/hero-fe/src/router/guard.ts
+++ b/hero-fe/src/router/guard.ts
@@ -29,7 +29,8 @@ export function setupAuthGuard(router: Router) {
         // 디버깅: 어떤 경로로 이동을 시도하는지 확인합니다.
         console.log(`[Auth Guard] Navigating from '${from.fullPath}' to '${to.fullPath}' (name: ${String(to.name)})`);
 
-        const isProtectedRoute = to.name !== 'Login';
+        const publicRoutes = ['Login', 'FindPassword', 'ResetPassword'];
+        const isProtectedRoute = !publicRoutes.includes(to.name as string);
 
         // 1. 보호된 경로에 접근하려 하고, 현재 인증되지 않은 경우에만 토큰 갱신을 시도합니다.
         if (isProtectedRoute && !authStore.isAuthenticated) {

--- a/hero-fe/src/router/modules/auth.ts
+++ b/hero-fe/src/router/modules/auth.ts
@@ -24,6 +24,24 @@ const authRoutes: RouteRecordRaw[] = [
       hiddenLayout: true,
     },
   },
+  {
+    path: '/find-password',
+    name: 'FindPassword',
+    component: () => import('@/views/auth/FindPassword.vue'),
+    meta: {
+      title: '비밀번호 찾기',
+      hiddenLayout: true,
+    },
+  },
+  {
+    path: '/reset-password',
+    name: 'ResetPassword',
+    component: () => import('@/views/auth/ResetPassword.vue'),
+    meta: {
+      title: '비밀번호 재설정',
+      hiddenLayout: true,
+    },
+  },
 ];
 
 export default authRoutes;

--- a/hero-fe/src/router/modules/personnel.ts
+++ b/hero-fe/src/router/modules/personnel.ts
@@ -69,6 +69,14 @@ const personnelRoutes: RouteRecordRaw[] = [
           title: '승진 심사',
         }
       },
+      {
+        path: 'special',
+        name: 'SpecialPromotion',
+        component: () => import('@/views/personnel/special/SpecialPromotion.vue'),
+        meta: {
+          title: '특별 승진',
+        }
+      },
     ],
   }
 ];

--- a/hero-fe/src/types/auth/password.types.ts
+++ b/hero-fe/src/types/auth/password.types.ts
@@ -1,0 +1,23 @@
+// 비밀번호 변경 요청 (로그인 후)
+export interface PasswordChangeRequest {
+  currentPassword: string;
+  newPassword: string;
+}
+
+// 비밀번호 재설정 요청 (이메일 발송 요청)
+export interface PasswordResetRequest {
+  employeeNumber: string;
+  email: string;
+}
+
+// 비밀번호 재설정 (토큰 이용)
+export interface PasswordReset {
+  token: string;
+  newPassword: string;
+}
+
+// 로그인 응답 데이터 (Login.vue에서 사용)
+export interface LoginResponseData {
+  message: string;
+  passwordChangeRequired: boolean;
+}

--- a/hero-fe/src/types/personnel/promotion.types.ts
+++ b/hero-fe/src/types/personnel/promotion.types.ts
@@ -94,6 +94,15 @@ export interface PromotionReviewRequestDTO {
     comment?: string;
 }
 
+/**
+ * 특별 승진(즉시 승진) 요청 DTO
+ */
+export interface DirectPromotionRequestDTO {
+    employeeId: number;
+    targetGradeId: number;
+    reason: string;
+}
+
 // --- Response DTOs (응답 데이터) ---
 /**
  * 설정할 수 있는 부서, 직급을 알기 위한 옵션 조회용 DTO

--- a/hero-fe/src/views/auth/FindPassword.vue
+++ b/hero-fe/src/views/auth/FindPassword.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="find-password-container">
+    <div class="card">
+      <div class="header">
+        <h3>비밀번호 찾기</h3>
+        <p>가입된 사번과 이메일을 입력해 주세요.</p>
+      </div>
+      
+      <form @submit.prevent="handleSubmit" v-if="!isEmailSent">
+        <div class="form-group">
+          <label for="empNumber">사번</label>
+          <input type="text" id="empNumber" v-model="form.employeeNumber" required placeholder="사번 입력" />
+        </div>
+        <div class="form-group">
+          <label for="email">이메일</label>
+          <input type="email" id="email" v-model="form.email" required placeholder="example@hero.com" />
+        </div>
+        
+        <button type="submit" class="btn-submit" :disabled="isLoading">
+          {{ isLoading ? '전송 중...' : '비밀번호 재설정 메일 발송' }}
+        </button>
+        <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+      </form>
+
+      <div v-else class="success-message">
+        <div class="icon-check">✓</div>
+        <h4>메일 발송 완료</h4>
+        <p>
+          <strong>{{ form.email }}</strong>으로<br/>
+          비밀번호 재설정 링크를 보냈습니다.<br/>
+          메일함을 확인해 주세요.
+        </p>
+        <router-link to="/login" class="btn-link">로그인으로 돌아가기</router-link>
+      </div>
+
+      <div class="footer-link" v-if="!isEmailSent">
+        <router-link to="/login">로그인 페이지로 이동</router-link>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive } from 'vue';
+import { requestPasswordReset } from '@/api/auth/password.api';
+
+const form = reactive({
+  employeeNumber: '',
+  email: ''
+});
+
+const isLoading = ref(false);
+const isEmailSent = ref(false);
+const errorMessage = ref('');
+
+const handleSubmit = async () => {
+  isLoading.value = true;
+  errorMessage.value = '';
+
+  try {
+    await requestPasswordReset({
+      employeeNumber: form.employeeNumber,
+      email: form.email
+    });
+    isEmailSent.value = true;
+  } catch (error: any) {
+    errorMessage.value = error.response?.data?.message || '정보가 일치하지 않거나 오류가 발생했습니다.';
+  } finally {
+    isLoading.value = false;
+  }
+};
+</script>
+
+<style scoped>
+.find-password-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #f0f2f5;
+}
+
+.card {
+  background: white;
+  padding: 40px;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.header { text-align: center; margin-bottom: 30px; }
+.header h3 { color: #1C398E; margin: 0 0 8px 0; }
+.header p { color: #666; font-size: 14px; margin: 0; }
+
+.form-group { margin-bottom: 20px; }
+.form-group label { display: block; margin-bottom: 8px; font-weight: 600; color: #555; }
+.form-group input { width: 100%; padding: 12px; border: 1px solid #ddd; border-radius: 8px; box-sizing: border-box; }
+
+.btn-submit {
+  width: 100%; padding: 14px;
+  background: linear-gradient(180deg, #1C398E 0%, #162456 100%);
+  color: white; border: none; border-radius: 8px;
+  font-size: 16px; font-weight: 600; cursor: pointer; margin-top: 10px;
+}
+.btn-submit:disabled { background: #ccc; cursor: not-allowed; }
+
+.error-message { color: #dc3545; text-align: center; margin-top: 16px; font-size: 14px; }
+
+.footer-link { text-align: center; margin-top: 20px; }
+.footer-link a { color: #666; text-decoration: none; font-size: 14px; }
+.footer-link a:hover { text-decoration: underline; }
+
+.success-message { text-align: center; }
+.icon-check {
+  width: 60px; height: 60px;
+  background: #dcfce7; color: #166534;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 30px; margin: 0 auto 20px;
+}
+.success-message h4 { font-size: 20px; margin-bottom: 10px; }
+.success-message p { color: #666; line-height: 1.5; margin-bottom: 30px; }
+
+.btn-link {
+  display: inline-block; width: 100%; padding: 14px;
+  background: #f3f4f6; color: #333;
+  text-decoration: none; border-radius: 8px;
+  font-weight: 600; box-sizing: border-box;
+}
+</style>

--- a/hero-fe/src/views/auth/PasswordChangeModal.vue
+++ b/hero-fe/src/views/auth/PasswordChangeModal.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="modal-overlay">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>비밀번호 변경 안내</h3>
+        <p>보안을 위해 비밀번호 변경이 필요합니다.</p>
+      </div>
+      
+      <form @submit.prevent="handleSubmit" class="modal-body">
+        <div class="form-group">
+          <label>새 비밀번호</label>
+          <input 
+            type="password" 
+            v-model="newPassword" 
+            placeholder="8~16자 영문, 숫자, 특수문자 포함"
+            required 
+          />
+        </div>
+        <div class="form-group">
+          <label>새 비밀번호 확인</label>
+          <input 
+            type="password" 
+            v-model="confirmPassword" 
+            placeholder="비밀번호 재입력"
+            required 
+          />
+          <p v-if="passwordMismatch" class="error-text">비밀번호가 일치하지 않습니다.</p>
+        </div>
+
+        <div class="modal-actions">
+          <button type="submit" class="btn-submit" :disabled="isLoading">변경하기</button>
+        </div>
+        <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { changePassword } from '@/api/auth/password.api';
+
+const props = defineProps<{
+  currentPassword: string;
+}>();
+
+const emit = defineEmits(['success']);
+
+const newPassword = ref('');
+const confirmPassword = ref('');
+const isLoading = ref(false);
+const errorMessage = ref('');
+
+const passwordMismatch = computed(() => {
+  return !!newPassword.value && !!confirmPassword.value && newPassword.value !== confirmPassword.value;
+});
+
+const handleSubmit = async () => {
+  if (passwordMismatch.value) return;
+  
+  // 유효성 검사 (영문, 숫자, 특수문자 포함 8~16자)
+  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$/;
+  if (!passwordRegex.test(newPassword.value)) {
+      errorMessage.value = '비밀번호는 8~16자의 영문, 숫자, 특수문자를 포함해야 합니다.';
+      return;
+  }
+
+  isLoading.value = true;
+  errorMessage.value = '';
+
+  try {
+    await changePassword({
+      currentPassword: props.currentPassword,
+      newPassword: newPassword.value
+    });
+    alert('비밀번호가 변경되었습니다. 다시 로그인해주세요.');
+    emit('success');
+  } catch (error: any) {
+    errorMessage.value = error.response?.data?.message || '비밀번호 변경 중 오류가 발생했습니다.';
+  } finally {
+    isLoading.value = false;
+  }
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  padding: 30px;
+  border-radius: 12px;
+  width: 400px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.modal-header h3 { margin: 0 0 8px 0; color: #1C398E; }
+.modal-header p { margin: 0 0 20px 0; color: #666; font-size: 14px; }
+
+.form-group { margin-bottom: 16px; }
+.form-group label { display: block; margin-bottom: 6px; font-weight: 600; font-size: 14px; color: #333; }
+.form-group input { width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px; box-sizing: border-box; }
+
+.error-text { color: #dc3545; font-size: 12px; margin-top: 4px; }
+
+.btn-submit {
+  width: 100%; padding: 12px;
+  background: linear-gradient(180deg, #1C398E 0%, #162456 100%);
+  color: white; border: none; border-radius: 8px;
+  cursor: pointer; font-weight: 600;
+}
+.btn-submit:disabled { background: #ccc; cursor: not-allowed; }
+
+.error-message { color: #dc3545; text-align: center; margin-top: 12px; font-size: 14px; }
+</style>

--- a/hero-fe/src/views/auth/ResetPassword.vue
+++ b/hero-fe/src/views/auth/ResetPassword.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="reset-password-container">
+    <div class="card">
+      <div class="header">
+        <h3>비밀번호 재설정</h3>
+        <p>새로운 비밀번호를 설정해 주세요.</p>
+      </div>
+
+      <form @submit.prevent="handleSubmit">
+        <div class="form-group">
+          <label>새 비밀번호</label>
+          <input 
+            type="password" 
+            v-model="newPassword" 
+            placeholder="8~16자 영문, 숫자, 특수문자 포함"
+            required 
+          />
+        </div>
+        <div class="form-group">
+          <label>비밀번호 확인</label>
+          <input 
+            type="password" 
+            v-model="confirmPassword" 
+            placeholder="비밀번호 재입력"
+            required 
+          />
+          <p v-if="passwordMismatch" class="error-text">비밀번호가 일치하지 않습니다.</p>
+        </div>
+
+        <button type="submit" class="btn-submit" :disabled="isLoading || passwordMismatch">
+          비밀번호 변경
+        </button>
+        <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { resetPassword } from '@/api/auth/password.api';
+
+const route = useRoute();
+const router = useRouter();
+
+const token = ref('');
+const newPassword = ref('');
+const confirmPassword = ref('');
+const isLoading = ref(false);
+const errorMessage = ref('');
+
+const passwordMismatch = computed(() => {
+  return !!newPassword.value && !!confirmPassword.value && newPassword.value !== confirmPassword.value;
+});
+
+onMounted(() => {
+  // URL 쿼리에서 토큰 추출
+  const queryToken = route.query.token;
+  if (typeof queryToken === 'string') {
+    token.value = queryToken;
+  } else {
+    alert('유효하지 않은 접근입니다.');
+    router.push('/login');
+  }
+});
+
+const handleSubmit = async () => {
+  if (passwordMismatch.value || !token.value) return;
+
+  // 유효성 검사
+  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$/;
+  if (!passwordRegex.test(newPassword.value)) {
+      errorMessage.value = '비밀번호는 8~16자의 영문, 숫자, 특수문자를 포함해야 합니다.';
+      return;
+  }
+
+  isLoading.value = true;
+  errorMessage.value = '';
+
+  try {
+    await resetPassword({
+      token: token.value,
+      newPassword: newPassword.value
+    });
+    alert('비밀번호가 성공적으로 변경되었습니다.\n로그인 페이지로 이동합니다.');
+    router.push('/login');
+  } catch (error: any) {
+    errorMessage.value = error.response?.data?.message || '비밀번호 재설정에 실패했습니다. 링크가 만료되었을 수 있습니다.';
+  } finally {
+    isLoading.value = false;
+  }
+};
+</script>
+
+<style scoped>
+.reset-password-container {
+  display: flex; justify-content: center; align-items: center;
+  min-height: 100vh; background-color: #f0f2f5;
+}
+.card {
+  background: white; padding: 40px; border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  width: 100%; max-width: 400px;
+}
+.header { text-align: center; margin-bottom: 30px; }
+.header h3 { color: #1C398E; margin: 0 0 8px 0; }
+.header p { color: #666; font-size: 14px; margin: 0; }
+.form-group { margin-bottom: 20px; }
+.form-group label { display: block; margin-bottom: 8px; font-weight: 600; color: #555; }
+.form-group input { width: 100%; padding: 12px; border: 1px solid #ddd; border-radius: 8px; box-sizing: border-box; }
+.error-text { color: #dc3545; font-size: 12px; margin-top: 4px; }
+.btn-submit {
+  width: 100%; padding: 14px; background: linear-gradient(180deg, #1C398E 0%, #162456 100%);
+  color: white; border: none; border-radius: 8px; font-size: 16px; font-weight: 600; cursor: pointer; margin-top: 10px;
+}
+.btn-submit:disabled { background: #ccc; cursor: not-allowed; }
+.error-message { color: #dc3545; text-align: center; margin-top: 16px; font-size: 14px; }
+</style>

--- a/hero-fe/src/views/personnel/EmployeeList.vue
+++ b/hero-fe/src/views/personnel/EmployeeList.vue
@@ -64,10 +64,30 @@
       </div>
   
       <!-- 페이지네이션 -->
-      <div class="pagination-container">
-        <button :disabled="pagination.page === 0" @click="goToPage(pagination.page - 1)">이전</button>
-        <span>{{ pagination.page + 1 }} / {{ pagination.totalPages }}</span>
-        <button :disabled="pagination.page >= pagination.totalPages - 1" @click="goToPage(pagination.page + 1)">다음</button>
+      <div class="pagination">
+        <button
+          class="page-button"
+          :disabled="pagination.page === 0 || isLoading"
+          @click="goToPage(pagination.page - 1)"
+        >
+          이전
+        </button>
+        <button
+          v-for="page in pagination.totalPages"
+          :key="page"
+          class="page-button"
+          :class="{ 'page-active': page === pagination.page + 1 }"
+          @click="goToPage(page - 1)"
+        >
+          {{ page }}
+        </button>
+        <button
+          class="page-button"
+          :disabled="pagination.page >= pagination.totalPages - 1 || isLoading"
+          @click="goToPage(pagination.page + 1)"
+        >
+          다음
+        </button>
       </div>
     </div>
 
@@ -308,7 +328,7 @@ onMounted(() => {
   font-size: 16px;
 }
 
-.pagination-container {
+.pagination {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -316,16 +336,24 @@ onMounted(() => {
   gap: 10px;
 }
 
-.pagination-container button {
-  padding: 5px 10px;
-  border: 1px solid #e2e8f0;
+.page-button {
+  padding: 5px 12px;
+  border: 1px solid #cad5e2;
   background: white;
-  border-radius: 5px;
+  border-radius: 4px;
+  font-size: 14px;
+  color: #62748e;
   cursor: pointer;
 }
 
-.pagination-container button:disabled {
+.page-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+.page-button.page-active {
+  background: #155dfc;
+  border-color: #155dfc;
+  color: white;
 }
 </style>

--- a/hero-fe/src/views/personnel/special/SpecialPromotion.vue
+++ b/hero-fe/src/views/personnel/special/SpecialPromotion.vue
@@ -2,14 +2,12 @@
   <div class="special-promotion-page">
     <div class="header-section">
       <h1 class="page-title">특별 승진</h1>
-      <p class="page-description">목록에서 사원을 선택하여 특별 승진을 진행합니다.</p>
     </div>
 
     <div class="content-layout">
       <!-- Left Panel: Employee List -->
       <div class="list-panel">
         <div class="list-header">
-          <h3>승진 대상 사원</h3>
           <div class="search-wrapper">
             <input
               type="text"
@@ -62,10 +60,30 @@
           </table>
         </div>
 
-        <div class="pagination-container">
-          <button @click="goToPage(currentPage - 1)" :disabled="currentPage <= 1 || isLoadingList">이전</button>
-          <span>{{ currentPage }} / {{ totalPages }}</span>
-          <button @click="goToPage(currentPage + 1)" :disabled="currentPage >= totalPages || isLoadingList">다음</button>
+        <div class="pagination">
+          <button
+            class="page-button"
+            :disabled="currentPage === 1 || isLoadingList"
+            @click="goToPage(currentPage - 1)"
+          >
+            이전
+          </button>
+          <button
+            v-for="page in totalPages"
+            :key="page"
+            class="page-button"
+            :class="{ 'page-active': page === currentPage }"
+            @click="goToPage(page)"
+          >
+            {{ page }}
+          </button>
+          <button
+            class="page-button"
+            :disabled="currentPage >= totalPages || isLoadingList"
+            @click="goToPage(currentPage + 1)"
+          >
+            다음
+          </button>
         </div>
       </div>
 
@@ -356,11 +374,6 @@ const resetForm = () => {
   margin-bottom: 4px;
 }
 
-.page-description {
-  font-size: 14px;
-  color: #64748b;
-}
-
 .content-layout {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -384,14 +397,8 @@ const resetForm = () => {
   padding: 20px;
   border-bottom: 1px solid #e2e8f0;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
-}
-
-.list-header h3 {
-  font-size: 16px;
-  font-weight: 600;
-  color: #1e293b;
 }
 
 .table-container {
@@ -407,15 +414,15 @@ const resetForm = () => {
 .employee-table th,
 .employee-table td {
   padding: 12px 16px;
-  text-align: left;
+  text-align: center;
   border-bottom: 1px solid #f1f5f9;
   font-size: 14px;
 }
 
 .employee-table th {
-  background-color: #f8fafc;
-  font-weight: 500;
-  color: #64748b;
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  font-weight: 600;
+  color: white;
 }
 
 .employee-table tbody tr {
@@ -459,27 +466,35 @@ const resetForm = () => {
   to { transform: rotate(360deg); }
 }
 
-.pagination-container {
-  padding: 12px;
-  border-top: 1px solid #e2e8f0;
+.pagination {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 16px;
-  font-size: 14px;
+  padding: 16px;
+  gap: 10px;
+  background: #f8fafc;
+  border-top: 1px solid #e2e8f0;
 }
 
-.pagination-container button {
-  padding: 6px 12px;
-  border-radius: 6px;
-  border: 1px solid #d1d5db;
-  background-color: white;
+.page-button {
+  padding: 5px 12px;
+  border: 1px solid #cad5e2;
+  background: white;
+  border-radius: 4px;
+  font-size: 14px;
+  color: #62748e;
   cursor: pointer;
 }
 
-.pagination-container button:disabled {
-  opacity: 0.5;
+.page-button:disabled {
   cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.page-button.page-active {
+  background: #155dfc;
+  border-color: #155dfc;
+  color: white;
 }
 
 .form-panel .placeholder {
@@ -594,14 +609,14 @@ const resetForm = () => {
 }
 
 .btn-search {
-  background-color: #4b5563;
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
   color: white;
   padding: 0 16px;
   flex-shrink: 0;
 }
 
 .btn-search:hover {
-  background-color: #374151;
+  opacity: 0.9;
 }
 
 .btn-search:disabled {

--- a/hero-fe/src/views/personnel/special/SpecialPromotion.vue
+++ b/hero-fe/src/views/personnel/special/SpecialPromotion.vue
@@ -1,0 +1,735 @@
+<template>
+  <div class="special-promotion-page">
+    <div class="header-section">
+      <h1 class="page-title">특별 승진</h1>
+      <p class="page-description">목록에서 사원을 선택하여 특별 승진을 진행합니다.</p>
+    </div>
+
+    <div class="content-layout">
+      <!-- Left Panel: Employee List -->
+      <div class="list-panel">
+        <div class="list-header">
+          <h3>승진 대상 사원</h3>
+          <div class="search-wrapper">
+            <input
+              type="text"
+              class="form-input"
+              v-model="searchKeyword"
+              placeholder="사번 또는 이름으로 검색"
+              @keyup.enter="handleSearch"
+            />
+            <button class="btn btn-search" @click="handleSearch" :disabled="isLoadingList">
+              {{ isLoadingList ? '...' : '검색' }}
+            </button>
+          </div>
+        </div>
+
+        <div class="table-container">
+          <table class="employee-table">
+            <thead>
+              <tr>
+                <th>사번</th>
+                <th>이름</th>
+                <th>부서</th>
+                <th>직급</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-if="isLoadingList">
+                <td colspan="4" class="loading-cell">
+                  <div class="spinner"></div>
+                  <span>사원 목록을 불러오는 중...</span>
+                </td>
+              </tr>
+              <tr v-else-if="listError">
+                <td colspan="4" class="error-cell">{{ listError }}</td>
+              </tr>
+              <tr v-else-if="employeeList.length === 0">
+                <td colspan="4" class="no-data-cell">검색 결과가 없습니다.</td>
+              </tr>
+              <tr
+                v-for="employee in employeeList"
+                :key="employee.employeeId"
+                @click="selectEmployee(employee)"
+                :class="{ 'selected-row': targetEmployee?.employeeId === employee.employeeId }"
+              >
+                <td>{{ employee.employeeNumber }}</td>
+                <td>{{ employee.employeeName }}</td>
+                <td>{{ employee.departmentName }}</td>
+                <td>{{ employee.gradeName }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="pagination-container">
+          <button @click="goToPage(currentPage - 1)" :disabled="currentPage <= 1 || isLoadingList">이전</button>
+          <span>{{ currentPage }} / {{ totalPages }}</span>
+          <button @click="goToPage(currentPage + 1)" :disabled="currentPage >= totalPages || isLoadingList">다음</button>
+        </div>
+      </div>
+
+      <!-- Right Panel: Promotion Form -->
+      <div class="form-panel">
+        <div v-if="!targetEmployee" class="placeholder">
+          <img src="/images/personnel.svg" alt="사원 선택" class="placeholder-img" />
+          <p>왼쪽 목록에서 승진시킬 사원을 선택해주세요.</p>
+        </div>
+        <div v-else class="form-card">
+          <div class="form-header">
+            <h2>특별 승진 대상자 정보</h2>
+          </div>
+          <div class="form-body">
+            <div class="employee-info-card">
+              <div class="info-header">
+                <div class="avatar">{{ targetEmployee.employeeName.charAt(0) }}</div>
+                <div class="name-section">
+                  <span class="name">{{ targetEmployee.employeeName }}</span>
+                  <span class="emp-number">({{ targetEmployee.employeeNumber }})</span>
+                </div>
+              </div>
+              <div class="info-body">
+                <div class="info-row">
+                  <span class="label">현재 부서</span>
+                  <span class="value">{{ targetEmployee.departmentName }}</span>
+                </div>
+                <div class="info-row">
+                  <span class="label">현재 직급</span>
+                  <span class="value">{{ targetEmployee.gradeName }}</span>
+                </div>
+                <div class="info-row">
+                  <span class="label">현재 직책</span>
+                  <span class="value">{{ targetEmployee.jobTitleName }}</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="divider"></div>
+            <h3 class="section-title">승진 정보</h3>
+
+            <div class="form-group">
+              <label for="targetGrade" class="form-label">승진 직급</label>
+              <select id="targetGrade" class="form-input" v-model="targetGradeId">
+                <option disabled value="">
+                  {{
+                    isLoadingGrades
+                      ? '직급 정보를 불러오는 중...'
+                      : allGrades.length > 0 ? '직급을 선택하세요' : '직급 정보가 없습니다'
+                  }}
+                </option>
+                <option v-if="allGrades.length > 0 && availableGrades.length === 0" disabled>
+                  승진 가능한 상위 직급이 없습니다
+                </option>
+                <option v-for="grade in availableGrades" :key="grade.gradeId" :value="grade.gradeId">
+                  {{ grade.grade }}
+                </option>
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">발령 구분</label>
+              <div class="readonly-field">즉시 발령</div>
+              <p class="help-text">* 특별 승진은 승인 즉시 효력이 발생합니다.</p>
+            </div>
+
+            <div class="form-group">
+              <label for="promotionReason" class="form-label">승진 사유</label>
+              <textarea
+                id="promotionReason"
+                class="form-textarea"
+                v-model="reason"
+                rows="5"
+                placeholder="특별 승진 사유를 구체적으로 입력해주세요."
+              ></textarea>
+            </div>
+          </div>
+          <div class="form-footer">
+            <button class="btn btn-cancel" @click="selectEmployee(null)">선택 취소</button>
+            <button class="btn btn-submit" @click="submitPromotion" :disabled="!isSubmittable">
+              승진 결재 상신
+            </button>
+          </div>
+          <p v-if="submitError" class="error-message footer-error">{{ submitError }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { fetchEmployees } from '@/api/personnel/personnel';
+import { fetchPromotionOptions, promoteDirectly } from '@/api/personnel/promotion.api';
+import type { EmployeeListResponse } from '@/types/personnel/personnel';
+import type {
+  PromotionGradeDTO,
+  DirectPromotionRequestDTO,
+} from '@/types/personnel/promotion.types';
+
+const router = useRouter();
+
+// List & Search state
+const searchKeyword = ref('');
+const isLoadingList = ref(false);
+const listError = ref('');
+const employeeList = ref<EmployeeListResponse[]>([]);
+const targetEmployee = ref<EmployeeListResponse | null>(null);
+
+// Form state
+const targetGradeId = ref<number | ''>('');
+const reason = ref('');
+const submitError = ref('');
+const isLoadingGrades = ref(false);
+
+// Data
+const allGrades = ref<PromotionGradeDTO[]>([]);
+
+// Pagination state
+const currentPage = ref(1);
+const totalPages = ref(1);
+const totalElements = ref(0);
+const pageSize = 10;
+
+// Computed properties
+const availableGrades = computed(() => {
+  if (!targetEmployee.value || !allGrades.value.length) return [];
+  // 현재 직급보다 높은 직급만 선택 가능하도록 필터링합니다.
+  const currentGrade = allGrades.value.find(g => g.grade === targetEmployee.value?.gradeName);
+  if (!currentGrade || currentGrade.gradeId === undefined) {
+    // 현재 직급을 찾지 못하면 모든 직급 표시 (오류 방지)
+    return allGrades.value;
+  }
+  // gradeId가 높을수록 높은 직급이라고 가정합니다.
+  return allGrades.value.filter(grade => grade.gradeId !== undefined && grade.gradeId > currentGrade.gradeId!);
+});
+
+const isSubmittable = computed(() => {
+  return !!(targetEmployee.value && targetGradeId.value && reason.value.trim());
+});
+
+const loadGrades = async () => {
+  isLoadingGrades.value = true;
+  try {
+    const response = await fetchPromotionOptions();
+    // API 응답 타입 정의와 실제 데이터가 일치하지 않아 any로 캐스팅하여 처리
+    const data = response.data.data as any;
+    if (response.data.success && data.promotionGradeDTOList) {
+      allGrades.value = data.promotionGradeDTOList;
+    }
+  } catch (error) {
+    console.error('직급 정보 로딩 실패:', error);
+  } finally {
+    isLoadingGrades.value = false;
+  }
+};
+
+onMounted(async () => {
+  loadEmployees(1);
+  loadGrades();
+});
+
+const loadEmployees = async (page: number) => {
+  isLoadingList.value = true;
+  listError.value = '';
+  employeeList.value = [];
+
+  try {
+    const response = await fetchEmployees({
+      employeeName: searchKeyword.value.trim(),
+      size: pageSize,
+      page: page,
+    });
+    if (response.data.success && response.data.data.content) {
+      employeeList.value = response.data.data.content;
+      totalPages.value = response.data.data.totalPages;
+      currentPage.value = page;
+      totalElements.value = response.data.data.totalElements;
+      if (employeeList.value.length === 0) {
+        listError.value = '표시할 사원이 없습니다.';
+      }
+    } else {
+      listError.value = '사원 목록을 불러오는 데 실패했습니다.';
+    }
+  } catch (error) {
+    console.error('사원 목록 로딩 에러:', error);
+    listError.value = '서버 오류로 사원 목록을 가져올 수 없습니다.';
+  } finally {
+    isLoadingList.value = false;
+  }
+};
+
+const handleSearch = () => {
+  loadEmployees(1);
+};
+
+const goToPage = (page: number) => {
+  if (page < 1 || page > totalPages.value || page === currentPage.value) return;
+  loadEmployees(page);
+};
+
+const selectEmployee = (employee: EmployeeListResponse | null) => {
+  if (targetEmployee.value?.employeeId === employee?.employeeId) {
+    // 이미 선택된 사원을 다시 클릭하면 선택 해제
+    targetEmployee.value = null;
+  } else {
+    targetEmployee.value = employee;
+  }
+  // 직급 정보가 로드되지 않았을 경우 재시도
+  if (targetEmployee.value && allGrades.value.length === 0) {
+    loadGrades();
+  }
+};
+
+watch(targetEmployee, (newVal) => {
+  if (newVal === null) {
+    resetPromotionForm();
+  }
+});
+
+const submitPromotion = async () => {
+  if (!isSubmittable.value) return;
+  submitError.value = '';
+
+  if (!confirm(`${targetEmployee.value?.employeeName}님의 특별 승진 결재를 상신하시겠습니까?`)) {
+    return;
+  }
+
+  const payload: DirectPromotionRequestDTO = {
+    employeeId: targetEmployee.value!.employeeId,
+    targetGradeId: targetGradeId.value as number,
+    reason: reason.value,
+  };
+
+  try {
+    const response = await promoteDirectly(payload);
+    if (response.data.success) {
+      alert('특별 승진 결재가 상신되었습니다.');
+      // 성공 후 목록 새로고침 및 폼 초기화
+      targetEmployee.value = null;
+      loadEmployees(currentPage.value);
+    } else {
+      submitError.value = response.data.message || '승진 처리 중 오류가 발생했습니다.';
+    }
+  } catch (error: any) {
+    console.error('특별 승진 처리 에러:', error);
+    submitError.value = error.response?.data?.message || '서버와 통신 중 오류가 발생했습니다.';
+  }
+};
+
+const resetPromotionForm = () => {
+  targetGradeId.value = '';
+  reason.value = '';
+  submitError.value = '';
+};
+
+const resetForm = () => {
+  searchKeyword.value = '';
+  listError.value = '';
+  targetEmployee.value = null;
+  resetPromotionForm();
+  loadEmployees(1);
+};
+</script>
+
+<style scoped>
+.special-promotion-page {
+  width: 100%;
+  height: 100%;
+  background-color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header-section {
+  background: white;
+  padding: 24px;
+  border-bottom: 1px solid #e2e8f0;
+  flex-shrink: 0;
+}
+
+.page-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 4px;
+}
+
+.page-description {
+  font-size: 14px;
+  color: #64748b;
+}
+
+.content-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  padding: 24px;
+  height: 100%;
+  overflow: hidden;
+}
+
+.list-panel,
+.form-panel {
+  background: white;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.list-header {
+  padding: 20px;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.list-header h3 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.table-container {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.employee-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.employee-table th,
+.employee-table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid #f1f5f9;
+  font-size: 14px;
+}
+
+.employee-table th {
+  background-color: #f8fafc;
+  font-weight: 500;
+  color: #64748b;
+}
+
+.employee-table tbody tr {
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.employee-table tbody tr:hover {
+  background-color: #f1f5f9;
+}
+
+.employee-table .selected-row {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.loading-cell, .error-cell, .no-data-cell {
+  text-align: center;
+  padding: 40px;
+  color: #64748b;
+}
+
+.loading-cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid #e2e8f0;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.pagination-container {
+  padding: 12px;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  font-size: 14px;
+}
+
+.pagination-container button {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  background-color: white;
+  cursor: pointer;
+}
+
+.pagination-container button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.form-panel .placeholder {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  text-align: center;
+  color: #9ca3af;
+}
+
+.placeholder-img {
+  width: 120px;
+  height: 120px;
+  margin-bottom: 16px;
+  opacity: 0.7;
+}
+
+.form-card {
+  background: white;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.form-header {
+  padding: 24px;
+  border-bottom: 1px solid #e2e8f0;
+  flex-shrink: 0;
+}
+
+.form-header h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.form-body {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+}
+
+.search-wrapper {
+  display: flex;
+  gap: 8px;
+}
+
+.form-input,
+.form-textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background-color: #fff;
+  font-size: 14px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  box-sizing: border-box;
+}
+
+.form-input:focus,
+.form-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.form-textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.readonly-field {
+  padding: 10px 12px;
+  background-color: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  color: #374151;
+  font-size: 14px;
+}
+
+.help-text {
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.btn {
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: none;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-search {
+  background-color: #4b5563;
+  color: white;
+  padding: 0 16px;
+  flex-shrink: 0;
+}
+
+.btn-search:hover {
+  background-color: #374151;
+}
+
+.btn-search:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.error-message {
+  color: #ef4444;
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+.employee-info-card {
+  background-color: #f9fafb;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.info-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.name-section {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.emp-number {
+  font-size: 14px;
+  color: #64748b;
+}
+
+.info-body {
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+}
+
+.info-row .label {
+  color: #64748b;
+}
+
+.info-row .value {
+  color: #1e293b;
+  font-weight: 500;
+}
+
+.divider {
+  height: 1px;
+  background-color: #e2e8f0;
+  margin: 8px 0;
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 4px;
+}
+
+.form-footer {
+  padding: 16px 24px;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  background-color: #f8fafc;
+  flex-shrink: 0;
+}
+
+.btn-cancel {
+  background-color: white;
+  border: 1px solid #d1d5db;
+  color: #374151;
+}
+.btn-cancel:hover {
+  background-color: #f3f4f6;
+}
+
+.btn-submit {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: white;
+}
+.btn-submit:hover {
+  opacity: 0.9;
+}
+.btn-submit:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+}
+
+.footer-error {
+  text-align: right;
+  padding: 0 24px 16px;
+  background-color: #f8fafc;
+  margin: 0;
+}
+</style>


### PR DESCRIPTION
## 📋 작업 내용

- 로그인된 사용자가 자신의 비밀번호를 변경하는 기능을 구현했습니다.
- 초기 로그인 시 비밀번호 변경이 필요한 경우, 변경을 유도하는 모달을 구현했습니다.
- 비밀번호를 잊은 사용자가 이메일 인증을 통해 비밀번호를 재설정하는 '비밀번호 찾기' 플로우를 구현했습니다.

## 🔧 작업 상세

### 변경된 파일
- `src/views/auth/Login.vue`
  - 로그인 성공 응답의 `passwordChangeRequired` 값에 따라 비밀번호 변경 모달을 띄우는 로직을 추가했습니다.
  - '비밀번호 찾기' 버튼에 `/find-password` 경로로 이동하는 `router-link`를 적용했습니다.
- `src/views/auth/FindPassword.vue`
  - 비밀번호 재설정 이메일 발송을 요청하는 페이지를 신규 구현했습니다.
- `src/views/auth/ResetPassword.vue`
  - 이메일로 받은 토큰을 이용해 새 비밀번호를 설정하는 페이지를 신규 구현했습니다.
- `src/components/auth/PasswordChangeModal.vue`
  - 초기 로그인 및 마이페이지에서 사용할 비밀번호 변경 모달 컴포넌트를 신규 구현했습니다.
- `src/api/auth/password.api.ts` & `src/types/auth/password.types.ts`
  - 비밀번호 관련 API(변경, 재설정 요청, 재설정) 함수와 관련 TypeScript 타입을 정의했습니다.
- `src/router/modules/auth.ts`
  - 인증 관련 라우트 모듈에 `/find-password`, `/reset-password` 경로를 추가했습니다.
- `src/router/guard.ts`
  - 인증 가드의 예외 경로(`publicRoutes`)에 `FindPassword`, `ResetPassword`를 추가하여 비로그인 접근을 허용했습니다.

### 주요 로직 설명
- **초기 비밀번호 변경**: `Login.vue`에서 로그인 성공 시 백엔드로부터 `passwordChangeRequired: true` 응답을 받으면, `PasswordChangeModal` 컴포넌트를 활성화하여 사용자에게 즉시 비밀번호 변경을 요구합니다.
- **비밀번호 찾기**: `FindPassword.vue`에서 사용자가 사번과 이메일을 입력하고 '메일 발송' 버튼을 누르면, 백엔드에 토큰 발급 및 이메일 전송을 요청합니다.
- **비밀번호 재설정**: 사용자가 이메일로 받은 링크를 클릭하면 `ResetPassword.vue` 페이지로 이동합니다. 이 페이지는 URL 쿼리 파라미터로 전달된 토큰을 사용하여 새 비밀번호를 설정하는 API를 호출합니다.

## ✅ 테스트 체크리스트
- [x] 로컬 환경에서 정상 동작 확인
- [x] 주요 기능 시나리오 테스트 완료
  - [x] 로그인 성공 후 비밀번호 변경 모달 정상 출력
  - [x] 비밀번호 찾기 페이지에서 이메일 발송 요청 성공
  - [x] 이메일 링크를 통해 재설정 페이지 접근 및 비밀번호 변경 성공


## 🖼️ 스크린샷 (UI 변경 시)

### 최초 로그인 시 강제 비밀번호 변경
<img width="590" height="621" alt="image" src="https://github.com/user-attachments/assets/872fbcb3-5893-409d-9eda-004b4c70e85e" />

### 비밀번호 찾기
<img width="552" height="594" alt="image" src="https://github.com/user-attachments/assets/343e5b94-985e-4552-85b2-4dc76487012e" />
<img width="565" height="583" alt="image" src="https://github.com/user-attachments/assets/8072ccfa-8c3f-4b1f-98af-a8d76ac40a08" />

### 이메일
<img width="634" height="315" alt="image" src="https://github.com/user-attachments/assets/ef3048a8-1555-44bf-86ba-e8a65b9d6cc3" />

### 비밀번호 변경
<img width="569" height="562" alt="image" src="https://github.com/user-attachments/assets/b12f6c91-efcf-4aa5-8fa6-2d4fa64b8c04" />


## 🤔 리뷰 포인트
- `Login.vue`에서 로그인 성공 후 `passwordChangeRequired` 값에 따라 모달을 띄우는 분기 로직을 중점적으로 확인해주시면 좋겠습니다.

## 🔗 관련 이슈
- Closes #75
- Closes #76
