### PR TITLE
[Feat] 조직도 페이지 상세 정보 조회 기능 구현

### DIFF
--- a/hero-fe/src/api/organization/organization.api.ts
+++ b/hero-fe/src/api/organization/organization.api.ts
@@ -7,12 +7,35 @@
  */
 
 import client from '@/api/apiClient';
-import type { OrganizationNode } from '@/types/organization/organization.types';
+import type { 
+  OrganizationNode,
+  DepartmentHistoryResponse,
+  GradeHistoryResponse,
+  ApiResponse,
+} from '@/types/organization/organization.types';
 
 /**
  * 조직도 트리 구조 조회
  * @returns 부서와 직원이 포함된 트리 구조의 최상위 노드 리스트
  */
 export const fetchOrganizationChart = () => {
-  return client.get<OrganizationNode[]>('/departments/organization-chart');
+  return client.get<ApiResponse<OrganizationNode[]>>('/departments/organization-chart');
+};
+
+/**
+ * 특정 직원의 부서 변경 이력을 조회합니다.
+ * @param employeeId 직원 ID
+ * @returns 부서 변경 이력 리스트
+ */
+export const fetchDepartmentHistory = (employeeId: number) => {
+  return client.get<ApiResponse<DepartmentHistoryResponse[]>>(`/departments/history/department/${employeeId}`);
+};
+
+/**
+ * 특정 직원의 직급 변경 이력을 조회합니다.
+ * @param employeeId 직원 ID
+ * @returns 직급 변경 이력 리스트
+ */
+export const fetchGradeHistory = (employeeId: number) => {
+  return client.get<ApiResponse<GradeHistoryResponse[]>>(`/departments/history/grade/${employeeId}`);
 };

--- a/hero-fe/src/api/organization/organization.api.ts
+++ b/hero-fe/src/api/organization/organization.api.ts
@@ -1,0 +1,18 @@
+/**
+ * File Name   : organization.api.ts
+ * Description : 조직도 관련 API 호출 모듈
+ *
+ * History
+ * 2025/12/29 - 승건 최초 작성
+ */
+
+import client from '@/api/apiClient';
+import type { OrganizationNode } from '@/types/organization/organization.types';
+
+/**
+ * 조직도 트리 구조 조회
+ * @returns 부서와 직원이 포함된 트리 구조의 최상위 노드 리스트
+ */
+export const fetchOrganizationChart = () => {
+  return client.get<OrganizationNode[]>('/departments/organization-chart');
+};

--- a/hero-fe/src/components/layout/TheSidebar.vue
+++ b/hero-fe/src/components/layout/TheSidebar.vue
@@ -421,6 +421,8 @@ const handleParentClick = (key: string) => {
     router.push('/');
   } else if (key === 'settings') {
     router.push('/settings');
+  } else if (key === 'organization') {
+    router.push('/organization');
   }
 
   //클릭한 메뉴만 토글, 나머지는 자동으로 열린 메뉴 닫기

--- a/hero-fe/src/router/index.ts
+++ b/hero-fe/src/router/index.ts
@@ -35,6 +35,7 @@ import { useAuthStore } from '@/stores/auth';
 import { useSessionStore } from '@/stores/session';
 
 import notificationRoutes from './modules/notification';
+import organizationRoutes from './modules/organization';
 
 
 // 전체 애플리케이션 라우트 정의
@@ -56,6 +57,7 @@ const routes: RouteRecordRaw[] = [
   ...evaluationRoutes,
   ...personnelRoutes,
   ...notificationRoutes,
+  ...organizationRoutes,
   ...settingsRoutes,
 ];
 

--- a/hero-fe/src/router/modules/organization.ts
+++ b/hero-fe/src/router/modules/organization.ts
@@ -1,0 +1,14 @@
+import type { RouteRecordRaw } from 'vue-router';
+
+const organizationRoutes: RouteRecordRaw[] = [
+  {
+    path: '/organization',
+    name: 'Organization',
+    component: () => import('@/views/organization/Index.vue'),
+    meta: {
+      title: '조직도',
+    },
+  },
+];
+
+export default organizationRoutes;

--- a/hero-fe/src/stores/organization/organization.store.ts
+++ b/hero-fe/src/stores/organization/organization.store.ts
@@ -8,36 +8,37 @@ export const useOrganizationStore = defineStore('organization', () => {
   const organizationChart = ref<OrganizationNode[]>([]);
   const deptHistoryList = ref<DepartmentHistoryResponse[]>([]);
   const gradeHistoryList = ref<GradeHistoryResponse[]>([]);
-  const isLoading = ref(false);
-  const error = ref<string | null>(null);
+  const isChartLoading = ref(false);
+  const isHistoryLoading = ref(false);
+  const chartError = ref<string | null>(null);
+  const historyError = ref<string | null>(null);
 
   // Actions
   const loadOrganizationChart = async () => {
-    isLoading.value = true;
-    error.value = null;
+    isChartLoading.value = true;
+    chartError.value = null;
     try {
       const response = await fetchOrganizationChart();
-      // API 응답 구조 대응 (CustomResponse.data 또는 직접 배열)
-      const data: any = response.data;
+      const data = response.data;
       if (data.success && data.data) {
         organizationChart.value = data.data;
-      } else if (Array.isArray(data)) {
-        organizationChart.value = data;
       } else {
         organizationChart.value = [];
       }
     } catch (err) {
-      error.value = '조직도 정보를 불러오는데 실패했습니다.';
+      chartError.value = '조직도 정보를 불러오는데 실패했습니다.';
       console.error(err);
     } finally {
-      isLoading.value = false;
+      isChartLoading.value = false;
     }
   };
 
   const loadDepartmentHistory = async (employeeId: number) => {
+    isHistoryLoading.value = true;
+    historyError.value = null;
     try {
       const response = await fetchDepartmentHistory(employeeId);
-      const data = response.data as ApiResponse<DepartmentHistoryResponse[]>;
+      const data = response.data;
       
       if (data.success && data.data) {
         deptHistoryList.value = data.data;
@@ -45,15 +46,19 @@ export const useOrganizationStore = defineStore('organization', () => {
         deptHistoryList.value = [];
       }
     } catch (err) {
+      historyError.value = '부서 이동 이력을 불러오는데 실패했습니다.';
       console.error(err);
-      throw err;
+    } finally {
+      isHistoryLoading.value = false;
     }
   };
 
   const loadGradeHistory = async (employeeId: number) => {
+    isHistoryLoading.value = true;
+    historyError.value = null;
     try {
       const response = await fetchGradeHistory(employeeId);
-      const data = response.data as ApiResponse<GradeHistoryResponse[]>;
+      const data = response.data;
 
       if (data.success && data.data) {
         gradeHistoryList.value = data.data;
@@ -61,8 +66,10 @@ export const useOrganizationStore = defineStore('organization', () => {
         gradeHistoryList.value = [];
       }
     } catch (err) {
+      historyError.value = '직급 변경 이력을 불러오는데 실패했습니다.';
       console.error(err);
-      throw err;
+    } finally {
+      isHistoryLoading.value = false;
     }
   };
 
@@ -70,8 +77,10 @@ export const useOrganizationStore = defineStore('organization', () => {
     organizationChart,
     deptHistoryList,
     gradeHistoryList,
-    isLoading,
-    error,
+    isChartLoading,
+    isHistoryLoading,
+    chartError,
+    historyError,
     loadOrganizationChart,
     loadDepartmentHistory,
     loadGradeHistory,

--- a/hero-fe/src/stores/organization/organization.store.ts
+++ b/hero-fe/src/stores/organization/organization.store.ts
@@ -1,0 +1,34 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { fetchOrganizationChart } from '@/api/organization/organization.api';
+import type { OrganizationNode } from '@/types/organization/organization.types';
+
+export const useOrganizationStore = defineStore('organization', () => {
+  // State
+  const organizationChart = ref<OrganizationNode[]>([]);
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
+
+  // Actions
+  const loadOrganizationChart = async () => {
+    isLoading.value = true;
+    error.value = null;
+    try {
+      const response = await fetchOrganizationChart();
+      // 백엔드에서 List<OrganizationNodeDTO>를 반환하므로 response.data가 배열입니다.
+      organizationChart.value = response.data;
+    } catch (err: any) {
+      console.error('조직도 로딩 실패:', err);
+      error.value = err.message || '조직도 데이터를 불러오는 중 오류가 발생했습니다.';
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  return {
+    organizationChart,
+    isLoading,
+    error,
+    loadOrganizationChart,
+  };
+});

--- a/hero-fe/src/types/organization/organization.types.ts
+++ b/hero-fe/src/types/organization/organization.types.ts
@@ -37,10 +37,49 @@ export interface OrganizationNode {
   departmentName: string;
   parentDepartmentId?: number | null;
   depth: number;
+  departmentPhone?: string; // 부서 전화번호
+  managerId?: number | null; // 부서장 ID
   
   // 하위 부서 목록
   children: OrganizationNode[];
   
   // 해당 부서에 소속된 직원 목록
   employees: OrganizationEmployeeDetail[];
+}
+
+/**
+ * 부서 변경 이력 DTO
+ * (Backend: EmployeeDepartmentHistoryDTO)
+ */
+export interface DepartmentHistoryResponse {
+  employeeHistoryId: number;
+  employeeId: number;
+  changedBy: number;
+  changedAt: string;
+  changeType: string;
+  departmentName: string;
+}
+
+/**
+ * 직급 변경 이력 DTO
+ * (Backend: EmployeeGradeHistoryDTO)
+ */
+export interface GradeHistoryResponse {
+  employeeHistoryId: number;
+  employeeId: number;
+  changedBy: number;
+  changedAt: string;
+  changeType: string;
+  gradeName: string;
+}
+
+/**
+ * API 공통 응답 포맷
+ * (Backend: CustomResponse<T>)
+ */
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  errorCode?: string;
+  message?: string;
 }

--- a/hero-fe/src/types/organization/organization.types.ts
+++ b/hero-fe/src/types/organization/organization.types.ts
@@ -19,8 +19,6 @@ export interface OrganizationEmployeeDetail {
   imagePath?: string;     // 프로필 이미지 경로 (Optional)
   
   email: string;          // 이메일
-  phone: string;          // 전화번호
-  address?: string;       // 주소 (Optional)
   birthDate?: string;     // 생년월일 (YYYY-MM-DD)
   gender: string;         // 성별
   hireDate: string;       // 입사일 (YYYY-MM-DD)

--- a/hero-fe/src/types/organization/organization.types.ts
+++ b/hero-fe/src/types/organization/organization.types.ts
@@ -1,0 +1,46 @@
+/**
+ * TypeScript Name : organization.types.ts
+ * Description : 조직도 관련 타입 정의
+ *
+ * History
+ * 2025/12/29 - 승건 최초 작성
+ */
+
+/**
+ * 조직도 내 직원 상세 정보
+ * (Backend: OrganizationEmployeeDetailDTO)
+ */
+export interface OrganizationEmployeeDetail {
+  employeeId: number;
+  employeeName: string;
+  employeeNumber: string; // 사번
+  gradeName: string;      // 직급명
+  jobTitleName: string;   // 직책명
+  imagePath?: string;     // 프로필 이미지 경로 (Optional)
+  
+  email: string;          // 이메일
+  phone: string;          // 전화번호
+  address?: string;       // 주소 (Optional)
+  birthDate?: string;     // 생년월일 (YYYY-MM-DD)
+  gender: string;         // 성별
+  hireDate: string;       // 입사일 (YYYY-MM-DD)
+  contractType: string;   // 고용 형태
+  status: string;         // 재직 상태
+}
+
+/**
+ * 조직도 트리 노드 (부서)
+ * (Backend: OrganizationNodeDTO)
+ */
+export interface OrganizationNode {
+  departmentId: number;
+  departmentName: string;
+  parentDepartmentId?: number | null;
+  depth: number;
+  
+  // 하위 부서 목록
+  children: OrganizationNode[];
+  
+  // 해당 부서에 소속된 직원 목록
+  employees: OrganizationEmployeeDetail[];
+}

--- a/hero-fe/src/views/organization/Index.vue
+++ b/hero-fe/src/views/organization/Index.vue
@@ -4,11 +4,11 @@
       <h1 class="title">조직도</h1>
     </div>
 
-    <div v-if="isLoading" class="loading-state">
+    <div v-if="isChartLoading" class="loading-state">
       <p>조직도 정보를 불러오는 중입니다...</p>
     </div>
-    <div v-else-if="error" class="error-state">
-      <p>{{ error }}</p>
+    <div v-else-if="chartError" class="error-state">
+      <p>{{ chartError }}</p>
       <button @click="loadData" class="retry-btn">다시 시도</button>
     </div>
 
@@ -141,7 +141,14 @@
           <button class="close-modal-btn" @click="closeModals">×</button>
         </div>
         <div class="modal-body">
-          <ul v-if="gradeHistoryList.length > 0" class="history-list">
+          <div v-if="isHistoryLoading" class="loading-state" style="height: 200px;">
+            <p>이력을 불러오는 중입니다...</p>
+          </div>
+          <div v-else-if="historyError" class="error-state" style="height: 200px;">
+            <p>{{ historyError }}</p>
+            <button @click="openGradeHistory" class="retry-btn">다시 시도</button>
+          </div>
+          <ul v-else-if="gradeHistoryList.length > 0" class="history-list">
             <li v-for="item in gradeHistoryList" :key="item.employeeHistoryId" class="history-item">
               <span class="history-date">{{ formatDate(item.changedAt) }}</span>
               <div class="history-detail">
@@ -163,7 +170,14 @@
           <button class="close-modal-btn" @click="closeModals">×</button>
         </div>
         <div class="modal-body">
-          <ul v-if="deptHistoryList.length > 0" class="history-list">
+          <div v-if="isHistoryLoading" class="loading-state" style="height: 200px;">
+            <p>이력을 불러오는 중입니다...</p>
+          </div>
+          <div v-else-if="historyError" class="error-state" style="height: 200px;">
+            <p>{{ historyError }}</p>
+            <button @click="openDeptHistory" class="retry-btn">다시 시도</button>
+          </div>
+          <ul v-else-if="deptHistoryList.length > 0" class="history-list">
             <li v-for="item in deptHistoryList" :key="item.employeeHistoryId" class="history-item">
               <span class="history-date">{{ formatDate(item.changedAt) }}</span>
               <div class="history-detail">
@@ -187,7 +201,7 @@ import type { OrganizationNode, OrganizationEmployeeDetail } from '@/types/organ
 import OrganizationTreeNode from './OrganizationTreeNode.vue';
 
 const store = useOrganizationStore();
-const { organizationChart, isLoading, error, deptHistoryList, gradeHistoryList } = storeToRefs(store);
+const { organizationChart, isChartLoading, isHistoryLoading, chartError, historyError, deptHistoryList, gradeHistoryList } = storeToRefs(store);
 
 const selectedDepartment = ref<OrganizationNode | null>(null);
 const selectedEmployee = ref<OrganizationEmployeeDetail | null>(null);
@@ -248,24 +262,14 @@ const onCenterListImageError = (id: number) => {
 
 const openDeptHistory = async () => {
   if (!selectedEmployee.value) return;
-  try {
-    await store.loadDepartmentHistory(selectedEmployee.value.employeeId);
-    showDeptModal.value = true;
-  } catch (e) {
-    console.error(e);
-    alert('부서 이력을 불러오는데 실패했습니다.');
-  }
+  showDeptModal.value = true; // 모달을 먼저 열어서 로딩 상태를 보여줌
+  await store.loadDepartmentHistory(selectedEmployee.value.employeeId);
 };
 
 const openGradeHistory = async () => {
   if (!selectedEmployee.value) return;
-  try {
-    await store.loadGradeHistory(selectedEmployee.value.employeeId);
-    showGradeModal.value = true;
-  } catch (e) {
-    console.error(e);
-    alert('직급 이력을 불러오는데 실패했습니다.');
-  }
+  showGradeModal.value = true; // 모달을 먼저 열어서 로딩 상태를 보여줌
+  await store.loadGradeHistory(selectedEmployee.value.employeeId);
 };
 
 const closeModals = () => {

--- a/hero-fe/src/views/organization/Index.vue
+++ b/hero-fe/src/views/organization/Index.vue
@@ -119,9 +119,11 @@
               <div class="info-item"><span class="label">부서</span><span class="value">{{ selectedDepartment?.departmentName }}</span></div>
               <div class="info-item"><span class="label">직책</span><span class="value">{{ selectedEmployee.jobTitleName }}</span></div>
               <div class="info-item"><span class="label">사번</span><span class="value">{{ selectedEmployee.employeeNumber }}</span></div>
-              <div class="info-item"><span class="label">이메일</span><span class="value">{{ selectedEmployee.email }}</span></div>
-              <div class="info-item"><span class="label">연락처</span><span class="value">{{ selectedEmployee.phone }}</span></div>
+              <div class="info-item"><span class="label">재직 상태</span><span class="value">{{ selectedEmployee.status }}</span></div>
               <div class="info-item"><span class="label">입사일</span><span class="value">{{ selectedEmployee.hireDate }}</span></div>
+              <div class="info-item"><span class="label">이메일</span><span class="value">{{ selectedEmployee.email }}</span></div>
+              <div class="info-item"><span class="label">생년월일</span><span class="value">{{ selectedEmployee.birthDate || '-' }}</span></div>
+              <div class="info-item"><span class="label">성별</span><span class="value">{{ formatGender(selectedEmployee.gender) }}</span></div>
             </div>
             
             <div class="action-buttons">
@@ -280,6 +282,13 @@ const closeModals = () => {
 const formatDate = (dateStr: string) => {
   if (!dateStr) return '-';
   return new Date(dateStr).toLocaleString();
+};
+
+const formatGender = (gender?: string) => {
+  if (!gender) return '-';
+  if (['M', 'Male', '남', '남자'].includes(gender)) return '남성';
+  if (['F', 'Female', '여', '여자'].includes(gender)) return '여성';
+  return gender;
 };
 
 onMounted(() => {

--- a/hero-fe/src/views/organization/Index.vue
+++ b/hero-fe/src/views/organization/Index.vue
@@ -1,0 +1,465 @@
+<template>
+  <div class="page-container">
+    <div class="header">
+      <h1 class="title">조직도</h1>
+    </div>
+
+    <div v-if="isLoading" class="loading-state">
+      <p>조직도 정보를 불러오는 중입니다...</p>
+    </div>
+    <div v-else-if="error" class="error-state">
+      <p>{{ error }}</p>
+      <button @click="loadData" class="retry-btn">다시 시도</button>
+    </div>
+
+    <div v-else class="content-grid">
+      <!-- Left Panel: Department List -->
+      <div class="panel department-list-panel">
+        <div class="panel-header">
+          <h2>부서 목록</h2>
+        </div>
+        <div class="panel-body">
+          <ul class="tree-root">
+            <OrganizationTreeNode
+              v-for="node in filteredOrganizationChart"
+              :key="node.departmentId"
+              :node="node"
+              :is-for-list="true"
+              :selected-department-id="selectedDepartment?.departmentId"
+              @select-department="handleSelectDepartment"
+            />
+          </ul>
+        </div>
+      </div>
+
+      <!-- Center Panel: Department Details -->
+      <div class="panel department-detail-panel">
+        <div v-if="!selectedDepartment" class="placeholder">
+          <p>왼쪽에서 부서를 선택해주세요.</p>
+        </div>
+        <div v-else class="department-details">
+          <div class="panel-header">
+            <h2>{{ selectedDepartment.departmentName }} 정보</h2>
+          </div>
+          <div class="panel-body">
+            <div v-if="selectedDepartment.children && selectedDepartment.children.length > 0" class="detail-section">
+              <h3 class="detail-title">하위 부서</h3>
+              <ul class="sub-department-list">
+                <li v-for="child in selectedDepartment.children" :key="child.departmentId" @click="handleSelectDepartment(child)" class="sub-department-item">
+                  <span>{{ child.departmentName }}</span>
+                  <span class="member-count">({{ getRecursiveMemberCount(child) }}명)</span>
+                </li>
+              </ul>
+            </div>
+            <div v-if="selectedDepartment.employees && selectedDepartment.employees.length > 0" class="detail-section">
+              <h3 class="detail-title">소속 인원</h3>
+              <ul class="employee-list-center">
+                <li v-for="emp in sortedEmployees" :key="emp.employeeId" @click="handleSelectEmployee(emp)" :class="{ 'selected': selectedEmployee?.employeeId === emp.employeeId }" class="employee-item-center">
+                  <div class="profile-img-wrapper">
+                    <img v-if="!centerListImageErrorIds.has(emp.employeeId)" :src="getProfileImageUrl(emp.imagePath)" @error="onCenterListImageError(emp.employeeId)" class="profile-img" alt="profile" />
+                    <div v-else class="profile-initial">{{ emp.employeeName.charAt(0) }}</div>
+                  </div>
+                  <div class="employee-info">
+                    <span class="employee-name">{{ emp.employeeName }} {{ emp.gradeName }}</span>
+                    <span class="employee-job">{{ emp.jobTitleName }}</span>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div v-if="(!selectedDepartment.children || selectedDepartment.children.length === 0) && (!selectedDepartment.employees || selectedDepartment.employees.length === 0)" class="no-content">
+              <p>하위 부서 또는 소속 인원이 없습니다.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right Panel: Employee Details -->
+      <div class="panel employee-detail-panel">
+        <div v-if="!selectedEmployee" class="placeholder">
+          <p>사원을 선택하여 상세 정보를 확인하세요.</p>
+        </div>
+        <div v-else class="employee-details">
+          <div class="panel-header">
+            <h2>사원 정보</h2>
+            <button @click="selectedEmployee = null" class="close-btn">×</button>
+          </div>
+          <div class="panel-body">
+            <div class="employee-profile-card">
+              <div class="profile-img-large-wrapper">
+                <img v-if="!selectedEmployeeImageError" :src="getProfileImageUrl(selectedEmployee.imagePath)" @error="selectedEmployeeImageError = true" class="profile-img-large" alt="profile" />
+                <div v-else class="profile-initial-large">{{ selectedEmployee.employeeName.charAt(0) }}</div>
+              </div>
+              <h3 class="employee-name-large">{{ selectedEmployee.employeeName }}</h3>
+              <p class="employee-grade-large">{{ selectedEmployee.gradeName }}</p>
+            </div>
+            <div class="employee-info-grid">
+              <div class="info-item"><span class="label">부서</span><span class="value">{{ selectedDepartment?.departmentName }}</span></div>
+              <div class="info-item"><span class="label">직책</span><span class="value">{{ selectedEmployee.jobTitleName }}</span></div>
+              <div class="info-item"><span class="label">사번</span><span class="value">{{ selectedEmployee.employeeNumber }}</span></div>
+              <div class="info-item"><span class="label">이메일</span><span class="value">{{ selectedEmployee.email }}</span></div>
+              <div class="info-item"><span class="label">연락처</span><span class="value">{{ selectedEmployee.phone }}</span></div>
+              <div class="info-item"><span class="label">입사일</span><span class="value">{{ selectedEmployee.hireDate }}</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useOrganizationStore } from '@/stores/organization/organization.store';
+import type { OrganizationNode, OrganizationEmployeeDetail } from '@/types/organization/organization.types';
+import OrganizationTreeNode from './OrganizationTreeNode.vue';
+
+const store = useOrganizationStore();
+const { organizationChart, isLoading, error } = storeToRefs(store);
+
+const filteredOrganizationChart = computed(() => {
+  return organizationChart.value?.filter(node => node.departmentName !== '관리자 부서') || [];
+});
+
+const sortedEmployees = computed(() => {
+  const employees = selectedDepartment.value?.employees;
+  if (!employees) return [];
+
+  return [...employees].sort((a, b) => {
+    // 1. 팀장 우선 (직책이 '팀장'인 경우 최상단)
+    const aIsLeader = a.jobTitleName === '팀장';
+    const bIsLeader = b.jobTitleName === '팀장';
+    if (aIsLeader && !bIsLeader) return -1;
+    if (!aIsLeader && bIsLeader) return 1;
+
+    // 2. 직급 순서 (높은 직급이 위로)
+    const gradeOrder: Record<string, number> = {
+      '사장': 1, '부사장': 2, '전무': 3, '상무': 4, '이사': 5,
+      '부장': 6, '차장': 7, '과장': 8, '대리': 9, '주임': 10, '사원': 11, '인턴': 12
+    };
+    const aRank = gradeOrder[a.gradeName] || 99;
+    const bRank = gradeOrder[b.gradeName] || 99;
+    
+    if (aRank !== bRank) return aRank - bRank;
+
+    // 3. 입사일 순 (먼저 입사한 사람이 위로)
+    const aDate = a.hireDate || '9999-12-31';
+    const bDate = b.hireDate || '9999-12-31';
+    return aDate.localeCompare(bDate);
+  });
+});
+
+const selectedDepartment = ref<OrganizationNode | null>(null);
+const selectedEmployee = ref<OrganizationEmployeeDetail | null>(null);
+const centerListImageErrorIds = ref(new Set<number>());
+const selectedEmployeeImageError = ref(false);
+
+const loadData = () => {
+  store.loadOrganizationChart();
+};
+
+const handleSelectDepartment = (department: OrganizationNode) => {
+  selectedDepartment.value = department;
+  selectedEmployee.value = null; // 부서 변경 시 사원 선택 해제
+  centerListImageErrorIds.value.clear();
+};
+
+const handleSelectEmployee = (employee: OrganizationEmployeeDetail) => {
+  selectedEmployee.value = employee;
+  selectedEmployeeImageError.value = false;
+};
+
+const getRecursiveMemberCount = (node: OrganizationNode): number => {
+  let count = node.employees?.length || 0;
+  if (node.children) {
+    for (const child of node.children) {
+      count += getRecursiveMemberCount(child);
+    }
+  }
+  return count;
+};
+
+const getProfileImageUrl = (path?: string) => {
+  if (!path) return '/images/default-profile.png';
+  if (path.startsWith('http')) return path;
+  
+  const baseUrl = 'http://localhost:8080';
+  let resourcePath = path.startsWith('/') ? path : `/${path}`;
+  if (!resourcePath.startsWith('/uploads')) {
+    resourcePath = `/uploads${resourcePath}`;
+  }
+  return `${baseUrl}${resourcePath}`;
+};
+
+const onCenterListImageError = (id: number) => {
+  centerListImageErrorIds.value.add(id);
+};
+
+onMounted(() => {
+  loadData();
+});
+</script>
+
+<style scoped>
+.page-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: #f8fafc;
+  overflow: hidden; 
+}
+
+.header {
+  width: 100%;
+  height: 60px;
+  background: white;
+  padding: 0 24px;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  align-items: center;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172b;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: 300px 1fr 350px;
+  grid-template-rows: minmax(0, 1fr);
+  gap: 24px;
+  flex: 1;
+  padding: 24px;
+  overflow: hidden;
+}
+
+.panel {
+  background: white;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.panel-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #e2e8f0;
+  flex-shrink: 0;
+}
+
+.panel-header h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.panel-body {
+  padding: 20px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.department-list-panel .panel-body {
+  padding: 12px;
+}
+
+.tree-root {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.loading-state,
+.error-state,
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #64748b;
+  text-align: center;
+}
+
+.placeholder p {
+  font-size: 14px;
+}
+
+.retry-btn {
+  margin-top: 12px;
+  padding: 8px 16px;
+  background-color: #1c398e;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.department-details, .employee-details {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* Center Panel */
+.detail-section {
+  margin-bottom: 24px;
+}
+.detail-title {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+.sub-department-list, .employee-list-center {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.sub-department-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+.sub-department-item:hover {
+  background-color: #f8fafc;
+}
+.member-count {
+  color: #94a3b8;
+  font-size: 13px;
+}
+.employee-item-center {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+.employee-item-center:hover, .employee-item-center.selected {
+  background-color: #eff6ff;
+}
+.profile-img-wrapper {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  overflow: hidden;
+  margin-right: 12px;
+  flex-shrink: 0;
+}
+.profile-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.profile-initial {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+.employee-info {
+  display: flex;
+  flex-direction: column;
+}
+.employee-name {
+  font-size: 14px;
+  font-weight: 600;
+}
+.employee-job {
+  font-size: 12px;
+  color: #64748b;
+}
+.no-content {
+  text-align: center;
+  color: #94a3b8;
+  padding: 40px 0;
+}
+
+/* Right Panel */
+.employee-detail-panel .panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: #94a3b8;
+}
+.employee-profile-card {
+  text-align: center;
+  padding-bottom: 24px;
+  border-bottom: 1px solid #f1f5f9;
+  margin-bottom: 24px;
+}
+.profile-img-large-wrapper {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  overflow: hidden;
+  margin: 0 auto 12px;
+  border: 3px solid white;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+.profile-img-large {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.profile-initial-large {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 32px;
+}
+.employee-name-large {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0;
+}
+.employee-grade-large {
+  font-size: 14px;
+  color: #64748b;
+}
+.employee-info-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+.info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.info-item .label {
+  font-size: 12px;
+  color: #94a3b8;
+}
+.info-item .value {
+  font-size: 14px;
+  font-weight: 500;
+  color: #334155;
+}
+</style>

--- a/hero-fe/src/views/organization/OrganizationTreeNode.vue
+++ b/hero-fe/src/views/organization/OrganizationTreeNode.vue
@@ -1,0 +1,277 @@
+<template>
+  <li class="tree-node">
+    <!-- 부서 노드 -->
+    <div class="department-content" @click="handleNodeClick" :class="{ 'is-card': isForList, 'selected': isForList && isSelected }">
+      <span class="toggle-icon" :class="{ 'is-open': isOpen, 'is-hidden': isLeaf }">
+        <img src="/images/dropdownArrow.png" class="arrow-img" alt="toggle" />
+      </span>
+      <span class="department-name">{{ node.departmentName }}</span>
+      <span class="member-count" v-if="totalMembers > 0">({{ totalMembers }})</span>
+    </div>
+
+    <!-- 자식 노드 (하위 부서 및 직원) -->
+    <ul v-show="isOpen" class="child-list">
+      <!-- 하위 부서 (재귀 렌더링) -->
+      <OrganizationTreeNode
+        v-for="child in node.children"
+        :key="child.departmentId"
+        :node="child"
+        :is-for-list="isForList"
+        :selected-department-id="selectedDepartmentId"
+        @select-employee="$emit('select-employee', $event)"
+        @select-department="$emit('select-department', $event)"
+      />
+      
+      <!-- 소속 직원 -->
+      <template v-if="!isForList">
+        <li v-for="emp in node.employees" :key="emp.employeeId" class="employee-node">
+          <div class="employee-card" @click.stop="$emit('select-employee', emp.employeeId)">
+            <div class="profile-img-wrapper">
+               <img v-if="!imageErrorIds.has(emp.employeeId)"
+                 :src="getProfileImageUrl(emp.imagePath)" 
+                 @error="onImageError(emp.employeeId)"
+                 class="profile-img" 
+                 alt="profile" 
+               />
+               <div v-else class="profile-initial">{{ emp.employeeName.charAt(0) }}</div>
+            </div>
+            <div class="employee-info">
+              <div class="employee-name">{{ emp.employeeName }} <span class="employee-grade">{{ emp.gradeName }}</span></div>
+              <div class="employee-job">{{ emp.jobTitleName }}</div>
+            </div>
+          </div>
+        </li>
+      </template>
+    </ul>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { OrganizationNode } from '@/types/organization/organization.types';
+
+const props = defineProps<{
+  node: OrganizationNode;
+  isForList?: boolean;
+  selectedDepartmentId?: number | null;
+}>();
+
+const emit = defineEmits(['select-employee', 'select-department']);
+
+const isOpen = ref(true); // 기본적으로 펼침 상태
+const imageErrorIds = ref(new Set<number>());
+
+const isSelected = computed(() => {
+  return props.node.departmentId === props.selectedDepartmentId;
+});
+
+const isLeaf = computed(() => {
+  if (props.isForList) {
+    return !props.node.children || props.node.children.length === 0;
+  }
+  return (!props.node.children || props.node.children.length === 0) && 
+         (!props.node.employees || props.node.employees.length === 0);
+});
+
+const getRecursiveMemberCount = (node: OrganizationNode): number => {
+  let count = node.employees?.length || 0;
+  if (node.children) {
+    for (const child of node.children) {
+      count += getRecursiveMemberCount(child);
+    }
+  }
+  return count;
+};
+
+const totalMembers = computed(() => {
+  if (props.isForList) {
+    return getRecursiveMemberCount(props.node);
+  }
+  return props.node.employees ? props.node.employees.length : 0;
+});
+
+const handleNodeClick = () => {
+  if (!isLeaf.value) {
+    isOpen.value = !isOpen.value;
+  }
+  if (props.isForList) {
+    emit('select-department', props.node);
+  }
+};
+
+// 프로필 이미지 URL 처리 (TheHeader.vue 로직 재사용)
+const getProfileImageUrl = (path?: string) => {
+  if (!path) return '/images/default-profile.png'; // 기본 이미지 경로 확인 필요
+  if (path.startsWith('http')) return path;
+  
+  const baseUrl = 'http://localhost:8080';
+  let resourcePath = path.startsWith('/') ? path : `/${path}`;
+  if (!resourcePath.startsWith('/uploads')) {
+    resourcePath = `/uploads${resourcePath}`;
+  }
+  return `${baseUrl}${resourcePath}`;
+};
+
+const onImageError = (id: number) => {
+  imageErrorIds.value.add(id);
+};
+</script>
+
+<style scoped>
+.tree-node {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.department-content {
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s;
+}
+
+.department-content:hover .department-name {
+  color: #1c398e;
+  font-weight: 700;
+}
+
+.department-content.is-card {
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 4px 0;
+  transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.department-content.is-card:hover {
+  border-color: #c7d2fe;
+  background-color: #f8fafc;
+}
+
+.department-content.is-card.selected {
+  background-color: #eef2ff;
+  border-color: #4f46e5;
+}
+
+.department-content.is-card.selected .department-name {
+  color: #1c398e;
+  font-weight: 700;
+}
+
+.toggle-icon {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 8px;
+  transition: transform 0.2s;
+}
+
+.toggle-icon.is-open {
+  transform: rotate(180deg);
+}
+
+.toggle-icon.is-hidden {
+  visibility: hidden;
+}
+
+.arrow-img {
+  width: 12px;
+  height: 8px;
+}
+
+.department-name {
+  font-weight: 600;
+  font-size: 15px;
+  color: #333;
+}
+
+.member-count {
+  margin-left: 6px;
+  font-size: 13px;
+  color: #888;
+}
+
+.child-list {
+  padding-left: 24px;
+  margin: 0;
+  border-left: 1px solid #e2e8f0;
+}
+
+.employee-node {
+  list-style: none;
+  margin: 4px 0;
+}
+
+.employee-card {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  width: fit-content;
+  min-width: 200px;
+}
+
+.employee-card:hover {
+  border-color: #1c398e;
+  box-shadow: 0 2px 8px rgba(28, 57, 142, 0.1);
+}
+
+.profile-img-wrapper {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  overflow: hidden;
+  margin-right: 12px;
+  background-color: #f1f5f9;
+  flex-shrink: 0;
+}
+
+.profile-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.profile-initial {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.employee-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.employee-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.employee-grade {
+  font-size: 12px;
+  color: #64748b;
+  font-weight: normal;
+  margin-left: 4px;
+}
+
+.employee-job {
+  font-size: 12px;
+  color: #94a3b8;
+}
+</style>


### PR DESCRIPTION
## 📋 작업 내용
> 전체 조직의 계층 구조를 시각화하고, 부서 및 사원 상세 정보를 확인할 수 있는 3단 레이아웃 기반의 조직도 페이지를 구현했습니다.

- 3단 스플릿 레이아웃(좌: 부서 트리, 중: 부서 상세, 우: 사원 상세)을 구현하여 조직 정보를 직관적으로 탐색할 수 있도록 했습니다.
- 부서 선택 시 중앙 패널에 하위 부서 및 소속 인원이 표시되며, 인원 선택 시 우측 패널에 상세 프로필이 나타납니다.
- 사원 프로필에서 '부서/직급 변경 이력'을 모달로 확인할 수 있는 기능을 추가했습니다.

## 🔧 작업 상세
> Pinia 스토어를 통해 조직도 데이터를 관리하고, 재귀 컴포넌트로 조직 계층을 렌더링하며, 3단 패널 간의 상태를 동기화하는 로직을 중심으로 개발했습니다.

### 변경된 파일
- `src/views/organization/Index.vue`
  - 조직도 페이지의 3단 레이아웃 구조 및 전체 UI 구현
  - 부서 및 사원 선택에 따른 데이터 동기화 로직 추가
  - 부서/직급 변경 이력 조회를 위한 모달 기능 연동
- `src/views/organization/OrganizationTreeNode.vue`
  - 부서 목록을 재귀적으로 렌더링하는 트리 노드 컴포넌트 신규 작성
- `src/stores/organization/organization.store.ts`
  - 조직도 데이터 fetching 및 상태 관리(부서/직급 이력 포함)를 위한 Pinia 스토어 신규 작성
- `src/types/organization/organization.types.ts`
  - 조직도 기능 관련 타입 정의 추가

### 주요 로직 설명
- **상태 관리**: Pinia(`useOrganizationStore`)를 활용하여 조직도 전체 데이터와 사원별 상세 이력(부서, 직급)을 비동기적으로 로드하고 상태를 관리합니다.
- **레이아웃**: CSS Grid를 사용하여 좌측(부서 목록), 중앙(부서 상세), 우측(사원 상세)으로 구성된 3단 레이아웃을 구현했습니다.
- **재귀 컴포넌트**: `OrganizationTreeNode` 재귀 컴포넌트를 통해 깊이에 제한 없는 조직 계층을 효율적으로 렌더링합니다.
- **데이터 동기화**: 부서 또는 사원 선택 시 `ref`로 관리되는 상태(`selectedDepartment`, `selectedEmployee`)를 업데이트하여 각 패널의 정보가 동기화되도록 구현했습니다.
- **이미지 에러 핸들링**: 사원 프로필 이미지 로드 실패 시, 이름의 첫 글자를 이니셜로 표시하는 대체 UI를 적용했습니다.

## ✅ 테스트 체크리스트
- [x] 로컬 환경에서 정상 동작 확인
- [x] 주요 기능 시나리오 테스트 완료 (부서 선택, 사원 선택, 이력 모달 확인)

## 🖼️ 스크린샷 (UI 변경 시)
> 조직도 페이지의 전체적인 3단 레이아웃과 각 패널의 상호작용을 보여줍니다.
<img width="1619" height="884" alt="image" src="https://github.com/user-attachments/assets/3dadd425-03a3-4f00-9abd-0add290021e8" />

<img width="1600" height="894" alt="image" src="https://github.com/user-attachments/assets/3f84934b-60fd-497b-bd2c-28f21b4feaa0" />

<img width="1586" height="870" alt="image" src="https://github.com/user-attachments/assets/6506f56f-fc5a-42ea-b787-368682e5dae5" />

<img width="547" height="777" alt="image" src="https://github.com/user-attachments/assets/8421df9d-fd33-4d58-980a-f1332a21b700" />

<img width="552" height="218" alt="image" src="https://github.com/user-attachments/assets/908d1fd3-a1aa-43bc-8520-a2af5ef3330e" />


## 🔗 관련 이슈

- Closes #77
