### PR TITLE
[Fix] 회수버튼숨기기/페이징처리/버튼css

### DIFF
--- a/hero-fe/src/assets/styles/approval/approval-inbox.css
+++ b/hero-fe/src/assets/styles/approval/approval-inbox.css
@@ -140,6 +140,15 @@ thead {
     background: linear-gradient(180deg, #1C398E 0%, #162456 100%);
 }
 
+th {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid #e2e8f0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 td {
     padding: 12px 16px;
     border-bottom: 1px solid #e2e8f0;
@@ -232,21 +241,21 @@ td {
 }
 
 .inbox-button {
-    border: 1px solid #e2e8f0;
-    border-radius: 10px;
-}
-
-.button-seq {
-    padding: 8px 15px;
-}
-
-.button-page {
-    padding: 7px 10px;
+    /* border: 1px solid #e2e8f0;
+    border-radius: 10px; */
+    padding: 5px 12px;
+    border-radius: 4px;
+    border: 1px solid #CAD5E2;
+    color: #62748E;
+    font-size: 14px;
+    cursor: pointer;
 }
 
 .button-page.active {
-    color: #ffff;
-    background-color: #155dfc;
+
+    background: #155DFC;
+    border: none;
+    color: #fff;
 }
 
 /* 클릭 가능한 행 스타일 */

--- a/hero-fe/src/views/approval/detail/ApprovalDetail.vue
+++ b/hero-fe/src/views/approval/detail/ApprovalDetail.vue
@@ -45,7 +45,7 @@
                             <span class="btn-text-white">삭제</span>
                         </button>
                     </template>
-                    <div v-if="document.docStatus === 'INPROGRESS'">
+                    <div v-if="(document.docStatus === 'INPROGRESS' && (document.drafterId === authStore.user?.employeeId))">
                         <button class="btn-primary-header" @click="handleCancel(document.docId)">
                             <img class="btn-icon" src="/images/cancel-white.svg" alt="회수">
                             <span class="btn-text-white">회수</span>

--- a/hero-fe/src/views/approval/inbox/ApprovalInbox.vue
+++ b/hero-fe/src/views/approval/inbox/ApprovalInbox.vue
@@ -15,11 +15,12 @@
   *   2025/12/29 (민철) 결재 상태별 뱃지 색상 구분 및 고정 크기 적용
   *   2025/12/29 (민철) 테이블 열 너비 조정 및 좌우 균형 배치
   *   2025/12/29 (민철) 전체 검색 기능 개선 (모든 필드에서 검색)
+  *   2026/01/01 (민철) 페이징 버튼 3개씩 표시하도록 개선
   * </pre>
   *
   * @module approval
   * @author 민철
-  * @version 3.4
+  * @version 3.5
 -->
 <template>
   <div class="inbox-container">
@@ -61,7 +62,7 @@
                 <option value="name">문서서식</option>
                 <option value="title">제목</option>
                 <option value="dept">부서</option>
-                <option value="drafter">상신자</option>
+                <option value="drafter">작성자</option>
               </select>
               <input type="text" placeholder="검색어를 입력하세요" class="input-box" v-model="searchKeyword"
                 @keyup.enter="onSearchChange">
@@ -73,21 +74,21 @@
           <table>
             <thead>
               <tr>
-                <td class="cell docNo">문서번호</td>
-                <td class="cell docStatus">결재상태</td>
-                <td class="cell docCategory">문서분류</td>
-                <td class="cell docName">문서서식</td>
-                <td class="cell docTitle">문서제목</td>
-                <td class="cell drafterDept">부서</td>
-                <td class="cell drafter">상신자</td>
-                <td class="cell drafterDate">상신일시</td>
+                <th class="cell docNo">문서번호</th>
+                <th class="cell docStatus">결재상태</th>
+                <th class="cell docCategory">문서분류</th>
+                <th class="cell docName">문서서식</th>
+                <th class="cell docTitle">문서제목</th>
+                <th class="cell drafterDept">부서</th>
+                <th class="cell drafter">작성자</th>
+                <th class="cell drafterDate">작성일시</th>
               </tr>
             </thead>
             <tbody>
               <template v-if="!loading && documents.length > 0">
                 <tr v-for="doc in documents" :key="doc.docId" class="clickable-row"
                   @click="toDocumentDetail(doc.docId)">
-                  <td class="cell docNo">{{ doc.docNo }}</td>
+                  <td class="cell docNo">{{ doc.docNo || '생성중' }}</td>
                   <td class="cell docStatus">
                     <div class="status-badge" :class="getStatusClass(doc.docStatus)">
                       {{ getStatusText(doc.docStatus) }}
@@ -119,12 +120,19 @@
 
         <div class="inbox-body-bottom">
           <div class="inbox-body-buttons">
-            <button class="inbox-button button-seq" @click="handlePageChange(page - 1)"
+            <button class="inbox-button" @click="handlePageChange(page - 1)"
               :disabled="page === 0">이전</button>
 
-            <button class="inbox-button button-page active">{{ page + 1 }}</button>
+            <button 
+              v-for="pageNum in visiblePages" 
+              :key="pageNum"
+              class="inbox-button button-page" 
+              :class="{ active: page === pageNum }"
+              @click="handlePageChange(pageNum)">
+              {{ pageNum + 1 }}
+            </button>
 
-            <button class="inbox-button button-seq" @click="handlePageChange(page + 1)"
+            <button class="inbox-button" @click="handlePageChange(page + 1)"
               :disabled="page >= totalPages - 1">다음</button>
           </div>
         </div>
@@ -136,7 +144,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useInbox } from '@/composables/approval/useInbox';
 
@@ -159,6 +167,46 @@ const fromDate = ref('');
 const toDate = ref('');
 const sortBy = ref('all');
 const searchKeyword = ref('');
+
+/**
+ * 보이는 페이지 번호 계산 (최대 3개)
+ * 현재 페이지를 중심으로 좌우 페이지 표시
+ */
+const visiblePages = computed(() => {
+  const total = totalPages.value;
+  const current = page.value;
+  const pages: number[] = [];
+
+  if (total === 0) return pages;
+
+  // 전체 페이지가 3개 이하인 경우
+  if (total <= 3) {
+    for (let i = 0; i < total; i++) {
+      pages.push(i);
+    }
+    return pages;
+  }
+
+  // 전체 페이지가 3개 초과인 경우
+  // 현재 페이지를 중심으로 좌우 1개씩 표시
+  let start = Math.max(0, current - 1);
+  let end = Math.min(total - 1, current + 1);
+
+  // 시작이 0이면 끝을 조정
+  if (start === 0) {
+    end = Math.min(total - 1, 2);
+  }
+  // 끝이 마지막이면 시작을 조정
+  else if (end === total - 1) {
+    start = Math.max(0, total - 3);
+  }
+
+  for (let i = start; i <= end; i++) {
+    pages.push(i);
+  }
+
+  return pages;
+});
 
 /**
  * 검색 조건 변경 핸들러
@@ -215,6 +263,4 @@ const getStatusText = (status: string): string => {
 
 </script>
 
-<style scoped>
-@import "@/assets/styles/approval/approval-inbox.css";
-</style>
+<style scoped src="@/assets/styles/approval/approval-inbox.css"></style>


### PR DESCRIPTION
## 📋 작업 내용
- 기안자가 아닌 사용자에 대해서도 회수 버튼이 보였던 부분을 기안자와 로그인한 사용자가 같은 경우 

## 🔧 작업 상세

### 변경된 파일
- `/src/views/approval/inbox/ApprovalInbox.vue` - 테이블 헤더라벨 변경 및 페이지 버튼 UI 수정
- `/src/views/approval/detail/ApprovalDetail.vue` -  기안자와 로그인 사용자가 같을 경우에만 대기 문서에서 회수 버튼 UI 보이도록 수정.

### 주요 로직 설명
- 페이지 버튼이 3개만 보이도록하고 페이지 버튼 UI를 위한 computed문
```
/**
 * 보이는 페이지 번호 계산 (최대 3개)
 * 현재 페이지를 중심으로 좌우 페이지 표시
 */
const visiblePages = computed(() => {
  const total = totalPages.value;
  const current = page.value;
  const pages: number[] = [];
  if (total === 0) return pages;
  // 전체 페이지가 3개 이하인 경우
  if (total <= 3) {
    for (let i = 0; i < total; i++) {
      pages.push(i);
    }
    return pages;
  }
  // 전체 페이지가 3개 초과인 경우
  // 현재 페이지를 중심으로 좌우 1개씩 표시
  let start = Math.max(0, current - 1);
  let end = Math.min(total - 1, current + 1);
  // 시작이 0이면 끝을 조정
  if (start === 0) {
    end = Math.min(total - 1, 2);
  }
  // 끝이 마지막이면 시작을 조정
  else if (end === total - 1) {
    start = Math.max(0, total - 3);
  }
  for (let i = start; i <= end; i++) {
    pages.push(i);
  }
  return pages;
});
```
## ✅ 테스트 체크리스트
- [x] 로컬 환경에서 정상 동작 확인
- [x] 주요 기능 시나리오 테스트 완료
- [x] 브라우저 콘솔 에러 없음
- [ ] 반응형 디자인 확인 (모바일/태블릿/데스크탑)
- [ ] 크로스 브라우저 테스트 (Chrome, Safari, Firefox)

## 🖼️ 스크린샷
### 페이징 처리 및 페이지 버튼 UI
<img width="1606" height="702" alt="image" src="https://github.com/user-attachments/assets/67667fe1-3307-4f49-ab92-9e7efb6b5704" />
<img width="1601" height="415" alt="image" src="https://github.com/user-attachments/assets/bfdadc55-4e72-4993-b28e-96f51f64da80" />


## 🤔 리뷰 포인트
- 페이지 버튼 css를 한 번 검토하시고, 다른 테이블 내 스타일 수정했으면 하는 부분도 검토하시고, 피드백 주세요.

## 🔗 관련 이슈
- Closes #43 

## 💬 추가 코멘트
<!--
> 리뷰어에게 전달하고 싶은 추가 내용이 있다면 자유롭게 작성해주세요.
-->
- 페이징 버튼은 이런식으로 맞추었습니다. 다른 부분 스타일 맞출부분 알려주세요.
