### PR TITLE
[Feat] 평가 이력 조회 모달 및 퇴직 현황 대시보드 구현

### DIFF
--- a/hero-fe/src/api/evaluation/evaluation.api.ts
+++ b/hero-fe/src/api/evaluation/evaluation.api.ts
@@ -1,0 +1,27 @@
+/**
+ * <pre>
+ * File Name   : evaluation.api.ts
+ * Description : 평가 관련 API 호출 모듈
+ *
+ * History
+ * 2025/01/02 - (승건) 최초 작성
+ * </pre>
+ */
+
+import client from '@/api/apiClient';
+import type { EmployeeEvaluationListResponseDTO } from '@/types/evaluation/evaluation.types';
+
+// 공통 응답 타입
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  error?: any;
+  message?: string;
+}
+
+/**
+ * 특정 직원의 평가 이력 목록 조회
+ */
+export const fetchEmployeeEvaluationList = (employeeId: number) => {
+  return client.get<ApiResponse<EmployeeEvaluationListResponseDTO[]>>(`/evaluation/evaluation-form/list/${employeeId}`);
+};

--- a/hero-fe/src/api/retirement/retirement.api.ts
+++ b/hero-fe/src/api/retirement/retirement.api.ts
@@ -1,0 +1,65 @@
+// c:\SWCamp_19th\Project_fin\Hero-FE\hero-fe\src\api\retirement\retirement.api.ts
+
+import apiClient from '@/api/apiClient';
+import type {
+  ApiResponse,
+  ExitReasonDTO,
+  RetirementSummaryDTO,
+  ExitReasonStatDTO,
+  TenureRetentionDTO,
+  NewHireStatDTO,
+  DepartmentTurnoverDTO,
+} from '@/types/retirement/retirement.types';
+
+// 백엔드 컨트롤러의 @RequestMapping("/api/retirement")에 맞춤
+// apiClient의 baseURL 설정에 따라 '/retirement' 또는 '/api/retirement'가 될 수 있으나,
+// 기존 EvaluationList 등을 참고하여 '/retirement'로 설정합니다. (apiClient가 /api를 붙인다고 가정)
+const BASE_URL = '/retirement';
+
+/**
+ * 퇴사 사유 목록 조회
+ */
+export const getExitReasons = async () => {
+  const response = await apiClient.get<ApiResponse<ExitReasonDTO[]>>(`${BASE_URL}/reasons`);
+  return response.data;
+};
+
+/**
+ * 퇴직 현황 요약 조회
+ */
+export const getRetirementSummary = async () => {
+  const response = await apiClient.get<ApiResponse<RetirementSummaryDTO>>(`${BASE_URL}/summary`);
+  return response.data;
+};
+
+/**
+ * 사유별 퇴직 통계 조회
+ */
+export const getExitReasonStats = async () => {
+  const response = await apiClient.get<ApiResponse<ExitReasonStatDTO[]>>(`${BASE_URL}/stats/reason`);
+  return response.data;
+};
+
+/**
+ * 근속 기간별 잔존율 조회
+ */
+export const getTenureRetentionStats = async () => {
+  const response = await apiClient.get<ApiResponse<TenureRetentionDTO[]>>(`${BASE_URL}/stats/tenure`);
+  return response.data;
+};
+
+/**
+ * 신입 정착률 및 이직률 조회
+ */
+export const getNewHireStats = async () => {
+  const response = await apiClient.get<ApiResponse<NewHireStatDTO[]>>(`${BASE_URL}/stats/new-hire`);
+  return response.data;
+};
+
+/**
+ * 부서별 이직률 조회
+ */
+export const getDepartmentTurnoverStats = async () => {
+  const response = await apiClient.get<ApiResponse<DepartmentTurnoverDTO[]>>(`${BASE_URL}/stats/department`);
+  return response.data;
+};

--- a/hero-fe/src/components/charts/BaseLineChart.vue
+++ b/hero-fe/src/components/charts/BaseLineChart.vue
@@ -54,6 +54,7 @@ const props = defineProps<{
   data: number[];
   tooltipLabelPrefix?: string; // 툴팁 앞에 붙는 텍스트 (예: '실수령액: ')
   currency?: boolean;          // 통화 표기(₩) 여부
+  color?: string;              // 선 색상
 }>();
 
 const chartRef = ref<HTMLCanvasElement | null>(null);
@@ -79,6 +80,8 @@ const buildChart = () => {
           data: props.data,
           tension: 0.3,
           fill: false,
+          borderColor: props.color || '#3b82f6',
+          backgroundColor: props.color || '#3b82f6',
         },
       ],
     },

--- a/hero-fe/src/components/layout/TheHeader.vue
+++ b/hero-fe/src/components/layout/TheHeader.vue
@@ -110,19 +110,7 @@ watch(() => user.value?.imagePath, () => {
 
 // 프로필 이미지 URL 계산
 const profileImageUrl = computed(() => {
-  const path = user.value?.imagePath;
-  if (!path) return '';
-
-  // http로 시작하는 외부 링크는 그대로 사용
-  if (path.startsWith('http')) return path;
-
-  // 상대 경로인 경우 백엔드 주소와 /uploads 프리픽스 조합
-  const baseUrl = 'http://localhost:8080';
-  let resourcePath = path.startsWith('/') ? path : `/${path}`;
-  if (!resourcePath.startsWith('/uploads')) {
-    resourcePath = `/uploads${resourcePath}`;
-  }
-  return `${baseUrl}${resourcePath}`;
+  return user.value?.imagePath || '';
 });
 
 // 메인 로고 버튼 클릭 시 대시보드 이동

--- a/hero-fe/src/components/layout/TheHeader.vue
+++ b/hero-fe/src/components/layout/TheHeader.vue
@@ -103,15 +103,16 @@ const handleImageError = () => {
   imageLoadError.value = true;
 };
 
-// 사용자 정보(이미지 경로)가 변경되면 에러 상태 초기화
-watch(() => user.value?.imagePath, () => {
+// 사용자 정보가 변경되면 에러 상태 초기화
+watch(() => user.value, () => {
   imageLoadError.value = false;
-});
+}, { deep: true });
 
 // 프로필 이미지 URL 계산
 const profileImageUrl = computed(() => {
-  return user.value?.imagePath || '';
+  return user.value?.imagePath||'';
 });
+
 
 // 메인 로고 버튼 클릭 시 대시보드 이동
 const goDashboard = () => {

--- a/hero-fe/src/components/layout/TheSidebar.vue
+++ b/hero-fe/src/components/layout/TheSidebar.vue
@@ -503,7 +503,7 @@ const handleSubMenuClick = (key: string) => {
   if (key === 'employeeList') {
     router.push('/personnel/list');
   } else if (key === 'turnover') {
-    router.push('/personnel/turnover'); // 이직률
+    router.push('/personnel/retirement/turnover'); // 이직률
   } else if (key === 'plan') {
     router.push('/personnel/promotion/plan');
   } else if (key === 'recommend') {

--- a/hero-fe/src/router/modules/personnel.ts
+++ b/hero-fe/src/router/modules/personnel.ts
@@ -61,6 +61,14 @@ const personnelRoutes: RouteRecordRaw[] = [
           title: '사원 프로필',
         },
       },
+      {
+        path: 'retirement/turnover',
+        name: 'Turnover',
+        component: () => import('@/views/personnel/retirement/Turnover.vue'),
+        meta: {
+          title: '이직률',
+        },
+      },
     ],
   },
   {

--- a/hero-fe/src/stores/evaluation/evaluation.store.ts
+++ b/hero-fe/src/stores/evaluation/evaluation.store.ts
@@ -1,0 +1,43 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { fetchEmployeeEvaluationList } from '@/api/evaluation/evaluation.api';
+import type { EmployeeEvaluationListResponseDTO } from '@/types/evaluation/evaluation.types';
+
+export const useEvaluationStore = defineStore('evaluation', () => {
+  // State
+  const evaluationList = ref<EmployeeEvaluationListResponseDTO[]>([]);
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  // Actions
+  /**
+   * 특정 직원의 평가 이력 목록을 조회합니다.
+   * @param employeeId 직원 ID
+   */
+  const getEvaluationList = async (employeeId: number) => {
+    loading.value = true;
+    error.value = null;
+    evaluationList.value = [];
+
+    try {
+      const response = await fetchEmployeeEvaluationList(employeeId);
+      if (response.data.success) {
+        evaluationList.value = response.data.data;
+      } else {
+        error.value = response.data.message || '평가 목록을 불러오는데 실패했습니다.';
+      }
+    } catch (err: any) {
+      console.error('평가 목록 조회 에러:', err);
+      error.value = err.response?.data?.message || '서버 통신 중 오류가 발생했습니다.';
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  return {
+    evaluationList,
+    loading,
+    error,
+    getEvaluationList
+  };
+});

--- a/hero-fe/src/stores/retirement/retirement.store.ts
+++ b/hero-fe/src/stores/retirement/retirement.store.ts
@@ -1,0 +1,60 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import {
+  getRetirementSummary,
+  getExitReasonStats,
+  getTenureRetentionStats,
+  getNewHireStats,
+  getDepartmentTurnoverStats,
+} from '@/api/retirement/retirement.api';
+import type {
+  RetirementSummaryDTO,
+  ExitReasonStatDTO,
+  TenureRetentionDTO,
+  NewHireStatDTO,
+  DepartmentTurnoverDTO,
+} from '@/types/retirement/retirement.types';
+
+export const useRetirementStore = defineStore('retirement', () => {
+  // State
+  const summary = ref<RetirementSummaryDTO | null>(null);
+  const reasonStats = ref<ExitReasonStatDTO[]>([]);
+  const tenureStats = ref<TenureRetentionDTO[]>([]);
+  const newHireStats = ref<NewHireStatDTO[]>([]);
+  const departmentStats = ref<DepartmentTurnoverDTO[]>([]);
+  const loading = ref(false);
+
+  // Actions
+  const fetchRetirementData = async () => {
+    loading.value = true;
+    try {
+      const [sumRes, reasonRes, tenureRes, newHireRes, deptRes] = await Promise.all([
+        getRetirementSummary(),
+        getExitReasonStats(),
+        getTenureRetentionStats(),
+        getNewHireStats(),
+        getDepartmentTurnoverStats(),
+      ]);
+
+      summary.value = sumRes.data;
+      reasonStats.value = reasonRes.data;
+      tenureStats.value = tenureRes.data;
+      newHireStats.value = newHireRes.data;
+      departmentStats.value = deptRes.data;
+    } catch (error) {
+      console.error('Failed to fetch retirement data:', error);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  return {
+    summary,
+    reasonStats,
+    tenureStats,
+    newHireStats,
+    departmentStats,
+    loading,
+    fetchRetirementData,
+  };
+});

--- a/hero-fe/src/types/evaluation/evaluation.types.ts
+++ b/hero-fe/src/types/evaluation/evaluation.types.ts
@@ -10,7 +10,7 @@
 
 // 평가 이력 목록 응답 DTO
 export interface EmployeeEvaluationListResponseDTO {
-  formId: number;
+  evaluationId: number;
   evaluationName: string;
   totalRank: string;
   createdAt: string;

--- a/hero-fe/src/types/evaluation/evaluation.types.ts
+++ b/hero-fe/src/types/evaluation/evaluation.types.ts
@@ -1,0 +1,17 @@
+/**
+ * <pre>
+ * File Name   : evaluation.types.ts
+ * Description : 평가 관련 타입 정의
+ *
+ * History
+ * 2025/01/02 - 최초 작성
+ * </pre>
+ */
+
+// 평가 이력 목록 응답 DTO
+export interface EmployeeEvaluationListResponseDTO {
+  formId: number;
+  evaluationName: string;
+  totalRank: string;
+  createdAt: string;
+}

--- a/hero-fe/src/types/retirement/retirement.types.ts
+++ b/hero-fe/src/types/retirement/retirement.types.ts
@@ -1,0 +1,66 @@
+// c:\SWCamp_19th\Project_fin\Hero-FE\hero-fe\src\types\retirement\retirement.types.ts
+
+/**
+ * API 공통 응답 래퍼
+ */
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  message?: string;
+  code?: string;
+}
+
+/**
+ * 퇴사 사유 DTO
+ */
+export interface ExitReasonDTO {
+  exitReasonId: number;
+  reasonName: string;
+  reasonType: string;
+  detailDescription: string;
+}
+
+/**
+ * 퇴직 현황 요약 DTO
+ */
+export interface RetirementSummaryDTO {
+  retentionRate: number;       // 잔존율
+  settlementRate: number;      // 정착율
+  totalTurnoverRate: number;   // 종합 이직률
+  newHireTurnoverRate: number; // 신입 이직률
+}
+
+/**
+ * 퇴사 사유별 통계 DTO
+ */
+export interface ExitReasonStatDTO {
+  reasonName: string;
+  count: number;
+}
+
+/**
+ * 근속 기간별 잔존율 DTO
+ */
+export interface TenureRetentionDTO {
+  tenureRange: string;
+  retentionRate: number;
+}
+
+/**
+ * 신입 사원 정착률 및 이직률 통계 DTO
+ */
+export interface NewHireStatDTO {
+  quarter: string;
+  settlementRate: number;
+  turnoverRate: number;
+}
+
+/**
+ * 부서별 이직률 통계 DTO
+ */
+export interface DepartmentTurnoverDTO {
+  departmentName: string;
+  currentCount: number;
+  retiredCount: number;
+  turnoverRate: number;
+}

--- a/hero-fe/src/views/evaluation/EvaluationFormDetail.vue
+++ b/hero-fe/src/views/evaluation/EvaluationFormDetail.vue
@@ -18,6 +18,13 @@
         <h1 class="title">평가서 상세</h1>
       </div>
     </div>
+    
+    <!-- ===== Modal Header (Back Button) ===== -->
+    <div class="modal-header-bar" v-else>
+      <button class="btn-back-modal" @click="goBack">
+        <span class="arrow">←</span> 목록으로 돌아가기
+      </button>
+    </div>
 
     <div class="content">
       <div class="form-box" :class="{ 'modal-form-box': isModal }">
@@ -230,8 +237,8 @@ const goBack = () => {
   else router.back();
 };
 
-const evaluationId = props.isModal ? props.modalEvaluationId! : Number(route.params.id);
-const employeeId = props.isModal ? props.modalEmployeeId! : Number(route.query.employeeId);
+const evaluationId = props.isModal ? (props.modalEvaluationId ?? 0) : Number(route.params.id);
+const employeeId = props.isModal ? (props.modalEmployeeId ?? 0) : Number(route.query.employeeId);
 
 //Reactive 데이터
 const evaluation = ref<any>({});
@@ -303,6 +310,11 @@ const renderChart = async () => {
  * 설명: 평가서 데이터 조회 메소드
  */
 const loadDetail = async () => {
+  if (!evaluationId || !employeeId) {
+    console.warn('유효하지 않은 평가 ID 또는 사원 ID입니다.', { evaluationId, employeeId });
+    return;
+  }
+
   try {
     const response = await apiClient.get(
       `/evaluation/evaluation-form/${evaluationId}/${employeeId}`
@@ -400,6 +412,26 @@ onMounted(loadDetail);
   height: 24px;
   cursor: pointer;
 }
+
+/* ================= Modal Header ================= */
+.modal-header-bar {
+  padding: 16px 24px 0 24px;
+  display: flex;
+  align-items: center;
+}
+
+.btn-back-modal {
+  background: none;
+  border: none;
+  color: #64748b;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.btn-back-modal:hover { color: #334155; }
 
 /* ================= Typography ================= */
 .section-title {

--- a/hero-fe/src/views/evaluation/EvaluationHistoryModal.vue
+++ b/hero-fe/src/views/evaluation/EvaluationHistoryModal.vue
@@ -30,9 +30,9 @@
           <ul v-else-if="store.evaluationList.length > 0" class="history-list">
             <li
               v-for="item in store.evaluationList"
-              :key="item.formId"
+              :key="item.evaluationId"
               class="history-item"
-              @click="openDetail(item.formId)"
+              @click="openDetail(item.evaluationId)"
             >
               <div class="item-info">
                 <span class="eval-name">{{ item.evaluationName }}</span>
@@ -78,8 +78,8 @@ watch(
   }
 );
 
-const openDetail = (formId: number) => {
-  selectedEvaluationId.value = formId;
+const openDetail = (evaluationId: number) => {
+  selectedEvaluationId.value = evaluationId;
 };
 
 const closeModal = () => {

--- a/hero-fe/src/views/evaluation/EvaluationHistoryModal.vue
+++ b/hero-fe/src/views/evaluation/EvaluationHistoryModal.vue
@@ -1,0 +1,211 @@
+<template>
+  <div v-if="isOpen" class="modal-overlay" @click.self="closeModal">
+    <div class="modal-content" :class="{ 'large-size': selectedEvaluationId }">
+      <!-- 모달 헤더 -->
+      <div class="modal-header">
+        <h3>{{ selectedEvaluationId ? '평가 상세 정보' : '평가 이력' }}</h3>
+        <button class="close-btn" @click="closeModal">×</button>
+      </div>
+
+      <!-- 모달 바디 -->
+      <div class="modal-body">
+        <!-- 1. 평가 상세 화면 -->
+        <div v-if="selectedEvaluationId" class="detail-view">
+          <EvaluationFormDetail
+            :is-modal="true"
+            :modal-evaluation-id="selectedEvaluationId"
+            :modal-employee-id="employeeId ?? undefined"
+            @close="selectedEvaluationId = null"
+          />
+        </div>
+
+        <!-- 2. 평가 이력 목록 화면 -->
+        <div v-else class="list-view">
+          <div v-if="store.loading" class="loading-state">
+            <p>이력을 불러오는 중입니다...</p>
+          </div>
+          <div v-else-if="store.error" class="error-state">
+            <p>{{ store.error }}</p>
+          </div>
+          <ul v-else-if="store.evaluationList.length > 0" class="history-list">
+            <li
+              v-for="item in store.evaluationList"
+              :key="item.formId"
+              class="history-item"
+              @click="openDetail(item.formId)"
+            >
+              <div class="item-info">
+                <span class="eval-name">{{ item.evaluationName }}</span>
+                <span class="eval-date">{{ formatDate(item.createdAt) }}</span>
+              </div>
+              <div class="item-grade">
+                <span class="grade-badge" :class="getGradeClass(item.totalRank)">
+                  {{ item.totalRank }}등급
+                </span>
+              </div>
+            </li>
+          </ul>
+          <p v-else class="no-data">평가 이력이 없습니다.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useEvaluationStore } from '@/stores/evaluation/evaluation.store';
+import EvaluationFormDetail from './EvaluationFormDetail.vue';
+
+const props = defineProps<{
+  isOpen: boolean;
+  employeeId: number | null;
+}>();
+
+const emit = defineEmits(['close']);
+
+const store = useEvaluationStore();
+const selectedEvaluationId = ref<number | null>(null);
+
+// 모달이 열리거나 직원 ID가 변경되면 목록 조회
+watch(
+  () => [props.isOpen, props.employeeId],
+  ([isOpen, empId]) => {
+    if (isOpen && empId) {
+      selectedEvaluationId.value = null; // 상세 화면 초기화
+      store.getEvaluationList(empId as number);
+    }
+  }
+);
+
+const openDetail = (formId: number) => {
+  selectedEvaluationId.value = formId;
+};
+
+const closeModal = () => {
+  emit('close');
+};
+
+const formatDate = (dateStr: string) => {
+  if (!dateStr) return '-';
+  return dateStr.split('T')[0];
+};
+
+const getGradeClass = (rank: string) => {
+  if (['S', 'A'].includes(rank)) return 'grade-high';
+  if (['B'].includes(rank)) return 'grade-mid';
+  return 'grade-low';
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  width: 500px;
+  height: 600px;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  transition: width 0.3s ease;
+}
+
+.modal-content.large-size {
+  width: 900px;
+  height: 80vh;
+}
+
+.modal-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+  background: #f8fafc;
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.history-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid #e2e8f0;
+  background: white;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.history-item:hover {
+  background-color: #f1f5f9;
+}
+
+.item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.eval-name {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.eval-date {
+  font-size: 13px;
+  color: #64748b;
+}
+
+.grade-badge {
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+.grade-high { background: #dbeafe; color: #1e40af; }
+.grade-mid { background: #f1f5f9; color: #475569; }
+.grade-low { background: #fee2e2; color: #991b1b; }
+
+.loading-state, .error-state, .no-data {
+  padding: 40px;
+  text-align: center;
+  color: #64748b;
+}
+
+.detail-view {
+  height: 100%;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #94a3b8;
+}
+</style>

--- a/hero-fe/src/views/organization/Index.vue
+++ b/hero-fe/src/views/organization/Index.vue
@@ -247,15 +247,7 @@ const getRecursiveMemberCount = (node: OrganizationNode): number => {
 };
 
 const getProfileImageUrl = (path?: string) => {
-  if (!path) return '/images/default-profile.png';
-  if (path.startsWith('http')) return path;
-  
-  const baseUrl = 'http://localhost:8080';
-  let resourcePath = path.startsWith('/') ? path : `/${path}`;
-  if (!resourcePath.startsWith('/uploads')) {
-    resourcePath = `/uploads${resourcePath}`;
-  }
-  return `${baseUrl}${resourcePath}`;
+  return path || '';
 };
 
 const onCenterListImageError = (id: number) => {

--- a/hero-fe/src/views/organization/OrganizationTreeNode.vue
+++ b/hero-fe/src/views/organization/OrganizationTreeNode.vue
@@ -101,15 +101,7 @@ const handleNodeClick = () => {
 
 // 프로필 이미지 URL 처리 (TheHeader.vue 로직 재사용)
 const getProfileImageUrl = (path?: string) => {
-  if (!path) return '/images/default-profile.png'; // 기본 이미지 경로 확인 필요
-  if (path.startsWith('http')) return path;
-  
-  const baseUrl = 'http://localhost:8080';
-  let resourcePath = path.startsWith('/') ? path : `/${path}`;
-  if (!resourcePath.startsWith('/uploads')) {
-    resourcePath = `/uploads${resourcePath}`;
-  }
-  return `${baseUrl}${resourcePath}`;
+  return path || '';
 };
 
 const onImageError = (id: number) => {

--- a/hero-fe/src/views/personnel/EmployeeDetailModal.vue
+++ b/hero-fe/src/views/personnel/EmployeeDetailModal.vue
@@ -126,19 +126,7 @@ const getEmployeeDetails = async (id: number) => {
 
 // 프로필 이미지 URL 계산
 const profileImageUrl = computed(() => {
-  const path = employee.value?.imagePath;
-  if (!path) return '';
-  
-  // 이미 전체 URL인 경우 (http로 시작)
-  if (path.startsWith('http')) return path;
-
-  // 상대 경로인 경우 백엔드 주소와 /uploads 프리픽스 조합
-  const baseUrl = 'http://localhost:8080';
-  let resourcePath = path.startsWith('/') ? path : `/${path}`;
-  if (!resourcePath.startsWith('/uploads')) {
-    resourcePath = `/uploads${resourcePath}`;
-  }
-  return `${baseUrl}${resourcePath}`;
+  return employee.value?.imagePath || '';
 });
 
 // 모달 열림/닫힘 감지

--- a/hero-fe/src/views/personnel/EmployeeList.vue
+++ b/hero-fe/src/views/personnel/EmployeeList.vue
@@ -17,6 +17,7 @@
                 <option :value="0">재직자 전원</option>
                 <option :value="1">재직자</option>
                 <option :value="2">퇴사예정자</option>
+                <option :value="3">퇴사자</option>
             </select>
             <select v-model="searchParams.departmentName" class="filter-select">
               <option value="">부서 전체</option>
@@ -169,7 +170,7 @@ const loadSearchOptions = async () => {
     const response = await fetchEmployeeSearchOptions();
     if (response.data.success) {
       const { department, grade, jobTitle } = response.data.data;
-      departmentOptions.value = department;
+      departmentOptions.value = department.sort();
       gradeOptions.value = grade;
       jobTitleOptions.value = jobTitle;
     }

--- a/hero-fe/src/views/personnel/EmployeeRegister.vue
+++ b/hero-fe/src/views/personnel/EmployeeRegister.vue
@@ -193,6 +193,26 @@ const handleSalaryInput = (event: Event) => {
   }
 };
 
+// 타입 가드: 객체가 message 속성(문자열)을 가지고 있는지 확인
+const hasMessage = (data: unknown): data is { message: string } => {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'message' in data &&
+    typeof (data as any).message === 'string'
+  );
+};
+
+// 타입 가드: 에러 객체가 response.data.message 구조를 가지고 있는지 확인
+const isErrorWithResponse = (error: unknown): error is { response: { data: { message: string } } } => {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    hasMessage((error as any).response?.data)
+  );
+};
+
 const handleSave = async () => {
   if (registrationType.value !== 'single') return;
 
@@ -229,10 +249,20 @@ const handleSave = async () => {
     if (response.data.success) {
       alert('사원이 성공적으로 등록되었습니다.');
       router.push('/personnel/list');
+    } else {
+      if (hasMessage(response.data)) {
+        alert(response.data.message);
+      } else {
+        alert('사원 등록에 실패했습니다.');
+      }
     }
   } catch (error) {
     console.error('사원 등록 오류:', error);
-    alert('사원 등록 중 오류가 발생했습니다.');
+    if (isErrorWithResponse(error)) {
+      alert(error.response.data.message);
+    } else {
+      alert('사원 등록 중 오류가 발생했습니다.');
+    }
   }
 };
 </script>

--- a/hero-fe/src/views/personnel/recommend/Recommend.vue
+++ b/hero-fe/src/views/personnel/recommend/Recommend.vue
@@ -166,11 +166,6 @@
               </div>
             </div>
 
-            <div class="extra-actions">
-                <button class="btn-extra">근태 관련</button>
-                <button class="btn-extra">평가 관련</button>
-            </div>
-
             <div class="member-action">
               <button 
                 v-if="!candidate.nominatorName && !candidate.nominationReason"

--- a/hero-fe/src/views/personnel/retirement/Turnover.vue
+++ b/hero-fe/src/views/personnel/retirement/Turnover.vue
@@ -1,0 +1,630 @@
+<!--
+  <pre>
+  (File => TypeScript / Vue) Name   : Turnover.vue
+  Description : 이직률 및 퇴직 현황 대시보드 페이지
+                - 퇴직 현황 요약 카드 (잔존율, 정착률, 이직률 등)
+                - 차트 시각화 (사유별, 근속기간별, 신입 통계)
+                - 부서별 이직률 테이블
+
+  History
+  2025/12/31 - 최초 작성
+  </pre>
+
+  @author Gemini
+  @version 1.0
+-->
+
+<template>
+  <div class="turnover-wrapper">
+    <div class="turnover-page">
+
+      <!-- 1. 상단 요약 카드 -->
+      <div class="summary-cards">
+        <div class="summary-card">
+          <div class="summary-title-row">
+            <span class="summary-title">잔존율</span>
+            <div class="tooltip-wrapper">
+              <span class="info-icon">i</span>
+              <span class="tooltip-text">최근 3년 전 재직 인원 중 현재까지 근무 중인 비율</span>
+            </div>
+          </div>
+          <div class="summary-value-wrapper">
+            <span class="summary-value">{{ summary?.retentionRate ?? 0 }}</span>
+            <span class="summary-unit">%</span>
+          </div>
+        </div>
+
+        <div class="summary-card">
+          <div class="summary-title-row">
+            <span class="summary-title">종합 이직률</span>
+            <div class="tooltip-wrapper">
+              <span class="info-icon">i</span>
+              <span class="tooltip-text">1년 전 재직 인원 대비 최근 1년간 발생한 퇴사자 비율</span>
+            </div>
+          </div>
+          <div class="summary-value-wrapper">
+            <span class="summary-value">{{ summary?.totalTurnoverRate ?? 0 }}</span>
+            <span class="summary-unit">%</span>
+          </div>
+        </div>
+
+        <div class="summary-card">
+          <div class="summary-title-row">
+            <span class="summary-title">신입 정착률</span>
+            <div class="tooltip-wrapper">
+              <span class="info-icon">i</span>
+              <span class="tooltip-text">최근 1년 입사자 중 3개월 이상 근무한 사원의 비율</span>
+            </div>
+          </div>
+          <div class="summary-value-wrapper">
+            <span class="summary-value">{{ summary?.settlementRate ?? 0 }}</span>
+            <span class="summary-unit">%</span>
+          </div>
+        </div>
+
+        <div class="summary-card">
+          <div class="summary-title-row">
+            <span class="summary-title">신입 이직률 (1년 내)</span>
+            <div class="tooltip-wrapper">
+              <span class="info-icon">i</span>
+              <span class="tooltip-text">최근 1년 내 입사한 신규 입사자 중 퇴사한 인원의 비율</span>
+            </div>
+          </div>
+          <div class="summary-value-wrapper">
+            <span class="summary-value">{{ summary?.newHireTurnoverRate ?? 0 }}</span>
+            <span class="summary-unit">%</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 2. 탭 및 컨텐츠 영역 -->
+      <div class="panel">
+        <!-- 탭 헤더 -->
+        <div class="panel-tabs">
+          <button
+            class="tab tab-left"
+            :class="{ 'tab-active': activeTab === 'reason' }"
+            @click="activeTab = 'reason'"
+          >
+            퇴사 사유
+          </button>
+          <button
+            class="tab"
+            :class="{ 'tab-active': activeTab === 'tenure' }"
+            @click="activeTab = 'tenure'"
+          >
+            근속 기간
+          </button>
+          <button
+            class="tab"
+            :class="{ 'tab-active': activeTab === 'newHire' }"
+            @click="activeTab = 'newHire'"
+          >
+            신입 통계
+          </button>
+          <button
+            class="tab tab-right"
+            :class="{ 'tab-active': activeTab === 'department' }"
+            @click="activeTab = 'department'"
+          >
+            부서별 현황
+          </button>
+        </div>
+
+        <!-- 탭 바디 -->
+        <div class="panel-body">
+          <!-- Tab 1: 퇴사 사유 -->
+          <div v-if="activeTab === 'reason'" class="chart-panel full-height">
+            <div class="panel-header">퇴사 사유별 통계</div>
+            <div class="chart-container">
+              <Doughnut v-if="reasonChartData" :data="reasonChartData" :options="doughnutOptions" />
+            </div>
+          </div>
+
+          <!-- Tab 2: 근속 기간 -->
+          <div v-if="activeTab === 'tenure'" class="chart-panel full-height">
+            <div style="display: flex; align-items: center; gap: 8px;">
+              <div class="panel-header">근속 기간별 잔존율</div>
+              <div class="tooltip-wrapper">
+                <span class="info-icon">i</span>
+                <span class="tooltip-text">해당 근속 연수에 도달할 수 있었던 입사자 중 실제 재직 중인 인원의 비율</span>
+              </div>
+            </div>
+            <div class="chart-container">
+              <BaseLineChart
+                v-if="tenureStats.length > 0"
+                :labels="tenureLabels"
+                :data="tenureData"
+                color="#1c398e"
+                tooltip-label-prefix="잔존율: "
+                tooltip-label-suffix="%"
+                y-axis-title="비율 (%)" />
+            </div>
+          </div>
+
+          <!-- Tab 3: 신입 통계 -->
+          <div v-if="activeTab === 'newHire'" class="chart-panel full-height">
+            <div style="display: flex; align-items: center; gap: 8px;">
+              <div class="panel-header">분기별 신입 사원 정착률 및 이직률</div>
+              <div class="tooltip-wrapper">
+                <span class="info-icon">i</span>
+                <span class="tooltip-text" style="text-align: left;">정착률: 3개월 이상 재직 신입<br>이직률: 1년 내 퇴사 신입</span>
+              </div>
+            </div>
+            <div class="chart-container">
+              <Bar v-if="newHireChartData" :data="newHireChartData" :options="newHireOptions" />
+            </div>
+          </div>
+
+          <!-- Tab 4: 부서별 이직률 테이블 -->
+          <div v-if="activeTab === 'department'" class="table-container">
+            <div class="panel-header-row">
+              <span class="panel-title">부서별 이직률 현황</span>
+            </div>
+            <div class="panel-table-wrapper">
+              <table class="turnover-table">
+                <thead>
+                  <tr>
+                    <th>부서명</th>
+                    <th class="text-center">현재 인원</th>
+                    <th class="text-center">퇴사 인원</th>
+                    <th class="text-center">이직률</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(row, index) in departmentStats" :key="row.departmentName" :class="{ 'row-striped': index % 2 === 1 }">
+                    <td>{{ row.departmentName }}</td>
+                    <td class="text-center">{{ row.currentCount }}명</td>
+                    <td class="text-center">{{ row.retiredCount }}명</td>
+                    <td class="text-center">
+                      <span :class="getTurnoverClass(row.turnoverRate)">
+                        {{ row.turnoverRate }}%
+                      </span>
+                    </td>
+                  </tr>
+                  <tr v-if="departmentStats.length === 0">
+                    <td colspan="4" class="empty-row">데이터가 없습니다.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, computed, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+import {
+  Chart as ChartJS,
+  Title,
+  Tooltip,
+  Legend,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  ArcElement
+} from 'chart.js';
+import { Bar, Doughnut } from 'vue-chartjs';
+
+import { useRetirementStore } from '@/stores/retirement/retirement.store';
+import BaseLineChart from '@/components/charts/BaseLineChart.vue';
+
+// Chart.js 등록
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, PointElement, LineElement, ArcElement);
+
+// --- State ---
+const store = useRetirementStore();
+const { summary, reasonStats, tenureStats, newHireStats, departmentStats } = storeToRefs(store);
+
+// --- Tab State ---
+const activeTab = ref('reason'); // 'reason' | 'tenure' | 'newHire' | 'department'
+
+// --- API Call ---
+onMounted(() => {
+  store.fetchRetirementData();
+});
+
+// --- Chart Data Computeds ---
+
+// 1. 사유별 퇴직 통계 (Doughnut)
+const reasonChartData = computed(() => {
+  if (!reasonStats.value.length) return null;
+  const colors = ['#1c398e', '#16a34a', '#eab308', '#ef4444', '#6366f1', '#8b5cf6', '#ec4899', '#f97316'];
+  return {
+    labels: reasonStats.value.map(item => `${item.reasonName} (${item.count}명)`),
+    datasets: [
+      {
+        backgroundColor: reasonStats.value.map((_, i) => colors[i % colors.length]),
+        data: reasonStats.value.map(item => item.count),
+        hoverOffset: 4
+      }
+    ]
+  };
+});
+
+// 2. 근속 기간별 잔존율 (BaseLineChart용 데이터)
+const tenureLabels = computed(() => tenureStats.value.map(item => item.tenureRange));
+const tenureData = computed(() => tenureStats.value.map(item => item.retentionRate));
+
+// 3. 신입 정착률/이직률 (Bar - Multi Dataset)
+const newHireChartData = computed(() => {
+  if (!newHireStats.value.length) return null;
+  return {
+    labels: newHireStats.value.map(item => item.quarter),
+    datasets: [
+      {
+        label: '정착률 (%)',
+        backgroundColor: '#16a34a', // Green
+        data: newHireStats.value.map(item => item.settlementRate),
+        borderRadius: 4,
+      },
+      {
+        label: '이직률 (%)',
+        backgroundColor: '#ef4444', // Red
+        data: newHireStats.value.map(item => item.turnoverRate),
+        borderRadius: 4,
+      }
+    ]
+  };
+});
+
+// --- Chart Options ---
+const commonOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      position: 'bottom',
+      labels: {
+        usePointStyle: true,
+        padding: 20,
+        font: { family: 'Inter-Regular', size: 12 }
+      }
+    }
+  },
+  scales: {
+    y: {
+      beginAtZero: true,
+      grid: { color: '#e2e8f0' },
+      ticks: { font: { family: 'Inter-Regular', size: 11 } }
+    },
+    x: {
+      grid: { display: false },
+      ticks: { font: { family: 'Inter-Regular', size: 11 } }
+    }
+  }
+};
+
+const barOptions = { ...commonOptions };
+const newHireOptions = { ...commonOptions };
+
+const doughnutOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  layout: {
+    padding: 20
+  },
+  plugins: {
+    legend: {
+      position: 'right' as const,
+      labels: {
+        usePointStyle: true,
+        padding: 20,
+        font: { family: 'Inter-Regular', size: 14 }
+      }
+    }
+  }
+};
+
+// --- Helper ---
+const getTurnoverClass = (rate: number) => {
+  if (rate >= 20) return 'text-danger';
+  if (rate >= 10) return 'text-warning';
+  return 'text-success';
+};
+</script>
+
+<style scoped>
+* {
+  font-size: 14px;
+  font-family: "Inter-Regular", sans-serif;
+  box-sizing: border-box;
+}
+
+.turnover-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background-color: #f8fafc;
+}
+
+.turnover-page {
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* 1. 상단 요약 카드 */
+.summary-cards {
+  display: flex;
+  gap: 16px;
+}
+
+.summary-card {
+  flex: 1;
+  background: #ffffff;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.02);
+}
+
+.summary-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.summary-title {
+  color: #64748b;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+/* 툴팁 스타일 */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: help;
+}
+
+.info-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: #e2e8f0;
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: serif;
+  font-style: italic;
+}
+
+.tooltip-text {
+  visibility: hidden;
+  width: 220px;
+  background-color: #334155;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 8px 10px;
+  position: absolute;
+  z-index: 10;
+  bottom: 135%;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.2s;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.4;
+  pointer-events: none;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+.tooltip-text::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #334155 transparent transparent transparent;
+}
+
+.tooltip-wrapper:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+.summary-value-wrapper {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.summary-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.summary-unit {
+  font-size: 16px;
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+/* 2. 패널 및 탭 스타일 */
+.panel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.panel-tabs {
+  display: flex;
+  flex-direction: row;
+}
+
+.tab {
+  width: 150px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  border-top: 1px solid #e2e8f0;
+  border-bottom: 1px solid #e2e8f0;
+  border-right: 1px solid #e2e8f0;
+  color: #64748b;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.tab-left {
+  border-left: 1px solid #e2e8f0;
+  border-top-left-radius: 14px;
+}
+
+.tab-right {
+  border-top-right-radius: 14px;
+}
+
+.tab-active {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+  color: #ffffff;
+  font-weight: 700;
+  border-color: transparent;
+}
+
+.panel-body {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-bottom-left-radius: 14px;
+  border-bottom-right-radius: 14px;
+  padding: 24px;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.chart-panel {
+  background: #ffffff;
+  border-radius: 14px;
+  border: 1px solid #e2e8f0;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 360px;
+}
+
+.full-height {
+  height: 100%;
+  min-height: 500px;
+}
+
+.panel-header {
+  font-size: 16px;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.chart-container {
+  flex: 1;
+  position: relative;
+  width: 100%;
+  min-height: 280px;
+}
+
+/* 3. 테이블 컨테이너 */
+.table-container {
+  width: 100%;
+}
+
+.panel-header-row {
+  padding: 0 0 16px 0;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 16px;
+}
+
+.panel-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.panel-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.turnover-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.turnover-table thead tr {
+  background: linear-gradient(180deg, #1c398e 0%, #162456 100%);
+}
+
+.turnover-table th {
+  padding: 14px 24px;
+  text-align: left;
+  font-weight: 600;
+  color: #ffffff;
+  font-size: 14px;
+}
+
+.turnover-table td {
+  padding: 16px 24px;
+  color: #475569;
+  border-bottom: 1px solid #f1f5f9;
+  font-size: 14px;
+}
+
+.turnover-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.turnover-table tbody tr.row-striped {
+  background-color: #f8fafc;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.empty-row {
+  text-align: center;
+  padding: 40px;
+  color: #94a3b8;
+}
+
+/* 이직률 상태 색상 */
+.text-danger {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+.text-warning {
+  color: #f59e0b;
+  font-weight: 600;
+}
+
+.text-success {
+  color: #16a34a;
+  font-weight: 600;
+}
+</style>

--- a/hero-fe/src/views/personnel/review/Review.vue
+++ b/hero-fe/src/views/personnel/review/Review.vue
@@ -187,17 +187,6 @@
             </template>
           </div>
         </div>
-
-        <!-- 전자 결재 상신 버튼 영역 -->
-        <div class="step-footer">
-          <div class="footer-info">
-            <p>심사가 완료되었나요?</p>
-            <span>전자 결재를 상신하여 최종 승인 절차를 진행하세요.</span>
-          </div>
-          <button class="btn-electronic-approval" @click="handleElectronicApproval" disabled title="기능 준비중입니다.">
-            📑 전자 결재 상신 (준비중)
-          </button>
-        </div>
       </div>
 
     </div>

--- a/hero-fe/src/views/personnel/review/Review.vue
+++ b/hero-fe/src/views/personnel/review/Review.vue
@@ -157,8 +157,8 @@
             </div>
 
             <div class="extra-actions">
-              <button class="btn-extra" disabled title="기능 준비중입니다.">평가 상세</button>
-              <button class="btn-extra" disabled title="기능 준비중입니다.">근태 상세</button>
+              <button class="btn-extra" @click="openEvaluationModal(candidate)">평가 상세</button>
+              <button class="btn-extra" @click="openAttendanceDrawer(candidate)">근태 상세</button>
             </div>
 
             <div class="member-action" v-if="!isReviewed(candidate)">
@@ -201,6 +201,20 @@
       </div>
 
     </div>
+
+    <!-- 근태 상세 드로어 -->
+    <EmployeeHalfChartDrawer
+      :open="showAttendanceDrawer"
+      :employee-id="attendanceEmployeeId"
+      @close="showAttendanceDrawer = false"
+    />
+
+    <!-- 평가 이력 모달 -->
+    <EvaluationHistoryModal
+      :is-open="showEvaluationModal"
+      :employee-id="evaluationEmployeeId"
+      @close="showEvaluationModal = false"
+    />
   </div>
 </template>
 
@@ -209,6 +223,8 @@ import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { usePromotionReviewStore } from '@/stores/personnel/promotionReview.store';
 import type { PromotionDetailForReviewResponseDTO, PromotionCandidateDTO, PromotionReviewRequestDTO } from '@/types/personnel/promotion.types';
+import EmployeeHalfChartDrawer from '@/views/attendance/attendanceDashBoard/EmplloyeeHalfChartDrawer.vue';
+import EvaluationHistoryModal from '@/views/evaluation/EvaluationHistoryModal.vue';
 
 const router = useRouter();
 const reviewStore = usePromotionReviewStore();
@@ -221,6 +237,28 @@ const editComment = ref('');
 const step = ref(1);
 const selectedPlanId = ref<number | null>(null);
 const selectedDetailPlan = ref<PromotionDetailForReviewResponseDTO | null>(null);
+
+// 근태 상세 드로어 상태
+const showAttendanceDrawer = ref(false);
+const attendanceEmployeeId = ref<number | null>(null);
+
+const openAttendanceDrawer = (candidate: PromotionCandidateDTO) => {
+  if (candidate.employeeId) {
+    attendanceEmployeeId.value = candidate.employeeId;
+    showAttendanceDrawer.value = true;
+  }
+};
+
+// 평가 이력 모달 상태
+const showEvaluationModal = ref(false);
+const evaluationEmployeeId = ref<number | null>(null);
+
+const openEvaluationModal = (candidate: PromotionCandidateDTO) => {
+  if (candidate.employeeId) {
+    evaluationEmployeeId.value = candidate.employeeId;
+    showEvaluationModal.value = true;
+  }
+};
 
 onMounted(() => {
   // 심사 가능한 계획 목록 조회


### PR DESCRIPTION
## 📋 작업 내용
- 승진 심사 및 조직도에서 사원의 평가 이력을 조회할 수 있는 모달 구현
- 퇴직 현황을 시각화하여 보여주는 대시보드(Turnover) 페이지 구현
- 사원 등록 시 유효성 검사 및 에러 핸들링 로직 강화

## 🔧 작업 상세
<!--
> 주요 변경 사항을 구체적으로 작성해주세요.
-->

### 변경된 파일
- `src/views/evaluation/EvaluationHistoryModal.vue` (신규)
- `src/views/evaluation/EvaluationFormDetail.vue`
- `src/views/personnel/retirement/Turnover.vue` (신규)
- `src/views/personnel/EmployeeRegister.vue`
- `src/components/layout/TheHeader.vue`
- `src/components/charts/BaseLineChart.vue`
- `src/stores/evaluation/evaluation.store.ts` (신규)
- `src/api/evaluation/evaluation.api.ts` (신규)

### 주요 로직 설명
1. **평가 이력 조회 모달 (`EvaluationHistoryModal`)**
   - 사원 ID를 기반으로 평가 이력 목록을 조회합니다.
   - 목록에서 항목 클릭 시 `EvaluationFormDetail` 컴포넌트를 모달 모드로 재사용하여 상세 내용을 표시합니다.
   - 상세 화면에서 '목록으로 돌아가기' 버튼을 통해 다시 이력 목록으로 이동할 수 있습니다.

2. **퇴직 현황 대시보드 (`Turnover`)**
   - **요약 카드**: 잔존율, 종합 이직률, 신입 정착률 등 핵심 지표 표시 (툴팁 포함).
   - **차트 시각화**: 
     - 퇴사 사유 (Doughnut Chart)
     - 근속 기간별 잔존율 (Line Chart)
     - 신입 사원 정착/이직률 (Bar Chart)
   - **부서별 현황**: 부서별 이직률 데이터를 테이블 형태로 제공.

3. **사원 등록 에러 핸들링 (`EmployeeRegister`)**
   - `hasMessage`, `isErrorWithResponse` 타입 가드 함수를 도입하여 API 에러 응답을 안전하게 파싱하고 사용자에게 명확한 메시지를 전달하도록 개선했습니다.

4. **기타 개선 사항**
   - **TheHeader**: 프로필 이미지 경로가 상대 경로일 경우와 절대 경로일 경우를 모두 처리하도록 로직 수정.

## ✅ 테스트 체크리스트
- [x] 로컬 환경에서 정상 동작 확인
- [x] 승진 심사 페이지에서 평가 상세 버튼 클릭 시 모달 정상 작동 확인
- [x] 퇴직 현황 대시보드 차트 및 데이터 렌더링 확인
- [x] 사원 등록 실패 시 에러 메시지 알림 확인
- [x] 브라우저 콘솔 에러 없음

## 🖼️ 스크린샷 (UI 변경 시)

### 평가 상세 버튼 클릭
<img width="1113" height="825" alt="image" src="https://github.com/user-attachments/assets/3beae793-4f7e-4855-bd6b-5f25cf0bc036" />

### 모달창에서 하나 클릭 시
<img width="1193" height="773" alt="image" src="https://github.com/user-attachments/assets/5b223941-8b53-4559-9759-57807ad1df67" />

### 근태 상세 버튼 클릭 시
<img width="1621" height="900" alt="image" src="https://github.com/user-attachments/assets/41e6cbd0-0639-4538-9c51-e9deba57a4a2" />

### 이직률 상단 카드 4종
<img width="1607" height="187" alt="image" src="https://github.com/user-attachments/assets/630dedb2-d83c-4052-877d-e9ff960512ed" />

### 이직 사유별 통계
<img width="1467" height="618" alt="image" src="https://github.com/user-attachments/assets/42fa74b5-f6eb-4df9-b2b3-d4308c79e758" />

### 근속 기간별 잔존
<img width="1535" height="644" alt="image" src="https://github.com/user-attachments/assets/f0bf87b5-2b91-4863-b0eb-b9396ae0e6bb" />

### 신입 통계
<img width="1507" height="663" alt="image" src="https://github.com/user-attachments/assets/f1609ade-76f2-4de3-9403-bc34eefbecae" />

### 부서별 통계
<img width="1545" height="725" alt="image" src="https://github.com/user-attachments/assets/e59824de-e44c-42cd-a386-f027b02f5063" />


## 🤔 리뷰 포인트

## 🔗 관련 이슈
- Closes #82 

