### PR TITLE
[Fix] 이직률 페이지 수정(사유별 통계, 근속별 잔존률)

### DIFF
--- a/hero-fe/src/api/retirement/retirement.api.ts
+++ b/hero-fe/src/api/retirement/retirement.api.ts
@@ -5,8 +5,8 @@ import type {
   ApiResponse,
   ExitReasonDTO,
   RetirementSummaryDTO,
-  ExitReasonStatDTO,
-  TenureRetentionDTO,
+  ExitReasonStatsResponseDTO,
+  TenureDistributionDTO,
   NewHireStatDTO,
   DepartmentTurnoverDTO,
 } from '@/types/retirement/retirement.types';
@@ -36,15 +36,15 @@ export const getRetirementSummary = async () => {
  * 사유별 퇴직 통계 조회
  */
 export const getExitReasonStats = async () => {
-  const response = await apiClient.get<ApiResponse<ExitReasonStatDTO[]>>(`${BASE_URL}/stats/reason`);
+  const response = await apiClient.get<ApiResponse<ExitReasonStatsResponseDTO>>(`${BASE_URL}/stats/reason`);
   return response.data;
 };
 
 /**
- * 근속 기간별 잔존율 조회
+ * 근속 연수별 인력 분포 조회
  */
-export const getTenureRetentionStats = async () => {
-  const response = await apiClient.get<ApiResponse<TenureRetentionDTO[]>>(`${BASE_URL}/stats/tenure`);
+export const getTenureDistributionStats = async () => {
+  const response = await apiClient.get<ApiResponse<TenureDistributionDTO[]>>(`${BASE_URL}/stats/tenure`);
   return response.data;
 };
 

--- a/hero-fe/src/components/layout/TheSidebar.vue
+++ b/hero-fe/src/components/layout/TheSidebar.vue
@@ -324,6 +324,7 @@
 
       <!-- 설정 관리 -->
       <div class="menu-item"
+          v-if="canSeeSettings"
           :class="{ 'active-parent': activeParent === 'settings' }"
           @click="handleParentClick('settings')">
         <div class="menu-content">
@@ -411,6 +412,11 @@ const canSeePersonnelParent = computed(() =>
 // 조직도 (EMPLOYEE)
 const canSeeOrganization = computed(() =>
   authStore.hasAnyRole(['ROLE_EMPLOYEE', 'ROLE_SYSTEM_ADMIN'])
+);
+
+// 설정 (SYSTEM_ADMIN, HR_MANAGER)
+const canSeeSettings = computed(() =>
+  authStore.hasAnyRole(['ROLE_SYSTEM_ADMIN', 'ROLE_HR_MANAGER'])
 );
 
 const router = useRouter();

--- a/hero-fe/src/components/layout/TheSidebar.vue
+++ b/hero-fe/src/components/layout/TheSidebar.vue
@@ -268,6 +268,7 @@
 
       <!-- 인사 관리 -->
       <div class="menu-item has-dropdown"
+          v-if="canSeePersonnelParent"
           :class="{ 'active-parent': activeParent === 'personnel' }"
           @click="handleParentClick('personnel')">
         <div class="menu-content">
@@ -282,27 +283,27 @@
       </div>
 
       <div v-if="isPersonnelOpen && !isCollapsed" class="sub-menu-list">
-        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'employeeList' }"
+        <div v-if="canSeePersonnelGeneral" class="sub-menu-item" :class="{ active: activeSubMenu === 'employeeList' }"
             @click="handleSubMenuClick('employeeList')">
           <div class="sub-menu-text">사원</div>
         </div>
-        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'turnover' }"
+        <div v-if="canSeePersonnelGeneral" class="sub-menu-item" :class="{ active: activeSubMenu === 'turnover' }"
             @click="handleSubMenuClick('turnover')">
           <div class="sub-menu-text">이직률</div>
         </div>
-        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'plan' }"
+        <div v-if="canSeePersonnelGeneral" class="sub-menu-item" :class="{ active: activeSubMenu === 'plan' }"
             @click="handleSubMenuClick('plan')">
           <div class="sub-menu-text">승진 계획 등록</div>
         </div>
-        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'recommend' }"
+        <div v-if="canSeePromotionRecommend" class="sub-menu-item" :class="{ active: activeSubMenu === 'recommend' }"
             @click="handleSubMenuClick('recommend')">
           <div class="sub-menu-text">승진 추천</div>
         </div>
-        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'review' }"
+        <div v-if="canSeePersonnelGeneral" class="sub-menu-item" :class="{ active: activeSubMenu === 'review' }"
             @click="handleSubMenuClick('review')">
           <div class="sub-menu-text">승진 심사</div>
         </div>
-        <div class="sub-menu-item" :class="{ active: activeSubMenu === 'special' }"
+        <div v-if="canSeePersonnelGeneral" class="sub-menu-item" :class="{ active: activeSubMenu === 'special' }"
             @click="handleSubMenuClick('special')">
           <div class="sub-menu-text">특별 승진</div>
         </div>
@@ -310,6 +311,7 @@
 
         <!-- 조직도 -->
         <div class="menu-item"
+             v-if="canSeeOrganization"
              :class="{ 'active-parent': activeParent === 'organization' }"
              @click="handleParentClick('organization')">
           <div class="menu-content">
@@ -390,6 +392,26 @@ const canSeeDeptDashboard = computed(() =>
     'ROLE_HR_EVALUATION',
   ])
 )
+
+// 사원 관리 일반 메뉴 (HR_TRANSFER)
+const canSeePersonnelGeneral = computed(() =>
+  authStore.hasAnyRole(['ROLE_HR_TRANSFER', 'ROLE_SYSTEM_ADMIN'])
+);
+
+// 승진 추천 (DEPT_MANAGER)
+const canSeePromotionRecommend = computed(() =>
+  authStore.hasAnyRole(['ROLE_DEPT_MANAGER', 'ROLE_SYSTEM_ADMIN'])
+);
+
+// 사원 관리 상위 메뉴 (하위 메뉴 중 하나라도 볼 수 있으면 노출)
+const canSeePersonnelParent = computed(() =>
+  canSeePersonnelGeneral.value || canSeePromotionRecommend.value
+);
+
+// 조직도 (EMPLOYEE)
+const canSeeOrganization = computed(() =>
+  authStore.hasAnyRole(['ROLE_EMPLOYEE', 'ROLE_SYSTEM_ADMIN'])
+);
 
 const router = useRouter();
 const route = useRoute();

--- a/hero-fe/src/stores/retirement/retirement.store.ts
+++ b/hero-fe/src/stores/retirement/retirement.store.ts
@@ -3,14 +3,14 @@ import { ref } from 'vue';
 import {
   getRetirementSummary,
   getExitReasonStats,
-  getTenureRetentionStats,
+  getTenureDistributionStats,
   getNewHireStats,
   getDepartmentTurnoverStats,
 } from '@/api/retirement/retirement.api';
 import type {
   RetirementSummaryDTO,
   ExitReasonStatDTO,
-  TenureRetentionDTO,
+  TenureDistributionDTO,
   NewHireStatDTO,
   DepartmentTurnoverDTO,
 } from '@/types/retirement/retirement.types';
@@ -18,8 +18,9 @@ import type {
 export const useRetirementStore = defineStore('retirement', () => {
   // State
   const summary = ref<RetirementSummaryDTO | null>(null);
-  const reasonStats = ref<ExitReasonStatDTO[]>([]);
-  const tenureStats = ref<TenureRetentionDTO[]>([]);
+  const earlyLeavers = ref<ExitReasonStatDTO[]>([]);
+  const totalLeavers = ref<ExitReasonStatDTO[]>([]);
+  const tenureStats = ref<TenureDistributionDTO[]>([]);
   const newHireStats = ref<NewHireStatDTO[]>([]);
   const departmentStats = ref<DepartmentTurnoverDTO[]>([]);
   const loading = ref(false);
@@ -31,13 +32,14 @@ export const useRetirementStore = defineStore('retirement', () => {
       const [sumRes, reasonRes, tenureRes, newHireRes, deptRes] = await Promise.all([
         getRetirementSummary(),
         getExitReasonStats(),
-        getTenureRetentionStats(),
+        getTenureDistributionStats(),
         getNewHireStats(),
         getDepartmentTurnoverStats(),
       ]);
 
       summary.value = sumRes.data;
-      reasonStats.value = reasonRes.data;
+      earlyLeavers.value = reasonRes.data.earlyLeavers;
+      totalLeavers.value = reasonRes.data.totalLeavers;
       tenureStats.value = tenureRes.data;
       newHireStats.value = newHireRes.data;
       departmentStats.value = deptRes.data;
@@ -50,11 +52,12 @@ export const useRetirementStore = defineStore('retirement', () => {
 
   return {
     summary,
-    reasonStats,
+    earlyLeavers,
+    totalLeavers,
     tenureStats,
     newHireStats,
     departmentStats,
-    loading,
+    loading,  
     fetchRetirementData,
   };
 });

--- a/hero-fe/src/types/retirement/retirement.types.ts
+++ b/hero-fe/src/types/retirement/retirement.types.ts
@@ -39,11 +39,19 @@ export interface ExitReasonStatDTO {
 }
 
 /**
- * 근속 기간별 잔존율 DTO
+ * 퇴사 사유 통계 응답 DTO
  */
-export interface TenureRetentionDTO {
+export interface ExitReasonStatsResponseDTO {
+  earlyLeavers: ExitReasonStatDTO[]; // 1년 미만 퇴사자 통계
+  totalLeavers: ExitReasonStatDTO[]; // 전체 퇴사자 통계
+}
+
+/**
+ * 근속 연수별 인력 분포 DTO
+ */
+export interface TenureDistributionDTO {
   tenureRange: string;
-  retentionRate: number;
+  percentage: number;
 }
 
 /**

--- a/hero-fe/src/views/personnel/promotion/PromotionPlan.vue
+++ b/hero-fe/src/views/personnel/promotion/PromotionPlan.vue
@@ -115,7 +115,7 @@ const goToPage = (page: number) => {
 
 const goToCreate = () => {
   // 승진 계획은 전자결재를 통해 생성되므로 결재 양식함으로 이동합니다.
-  router.push('/approval/create/promotionplan');
+  router.push('/approval/create/promotionplan?templateId=2');
 };
 
 const goToDetail = (id: number) => {


### PR DESCRIPTION
## 📋 작업 내용
2026.01.02 멘토링에서 피드백 받은 내용 수정
- 사유별 통계에서 근속 기간 1년 내인 사람만 개별로 볼 수 있게 수정
- 근속별 잔존률 -> 재직자의 연차별 분포로 변경

## 🔧 작업 상세

### 변경된 파일
- BE 변경에 따른 변경
 - hero-fe/src/api/retirement/retirement.api.ts
 - hero-fe/src/stores/retirement/retirement.store.ts
 - hero-fe/src/types/retirement/retirement.types.ts
- 사유별 통계 1년/전체 토글 버튼 추
 - hero-fe/src/views/personnel/retirement/Turnover.vue
 

## 🖼️ 스크린샷 (UI 변경 시)
<img width="1584" height="722" alt="image" src="https://github.com/user-attachments/assets/c3bf40a9-67cd-4696-8c10-0f938780aecb" />

<img width="1575" height="732" alt="image" src="https://github.com/user-attachments/assets/277f9c34-b448-4b0b-a606-a79ce35cf69c" />

<img width="1545" height="707" alt="image" src="https://github.com/user-attachments/assets/1534d89d-6d14-4301-b0bf-6034963d974d" />

