### PR TITLE
[fix] 인사발령 품의서의 reson칸이 readonly인 경우 크기가 auto가 되도록 함

### DIFF
--- a/hero-fe/src/assets/styles/approval/approval-appointment.css
+++ b/hero-fe/src/assets/styles/approval/approval-appointment.css
@@ -257,7 +257,7 @@
 
 .readonly-textarea {
   width: 100%;
-  height: 200px;
+  height: auto;
   background-color: #f9fafb;
   border: 1px solid #e2e8f0;
   border-radius: 10px;

--- a/hero-fe/src/views/personnel/review/Review.vue
+++ b/hero-fe/src/views/personnel/review/Review.vue
@@ -857,13 +857,13 @@ const handleElectronicApproval = () => {
 }
 
 .btn-approve {
-  background-color: #dbeafe;
-  color: #1e40af;
+  background-color: #3b82f6;
+  color: white;
 }
 
 .btn-reject {
-  background-color: #fee2e2;
-  color: #991b1b;
+  background-color: #ef4444;
+  color: white;
 }
 
 .no-data {


### PR DESCRIPTION
## 📋 작업 내용
- 인사 발령 품의서 상신 이후 내용 부분이 길게 작성되어 있는 경우 칸을 벗어나는 현상 확인해 수정
- 승진 심사에서 멤버 카드의 버튼내부 글씨가 안보이던 것 수정

## 🔧 작업 상세

### 변경된 파일
- hero-fe/src/assets/styles/approval/approval-appointment.css
- hero-fe/src/views/personnel/review/Review.vue


## 🖼️ 스크린샷 (UI 변경 시)
<img width="459" height="409" alt="image" src="https://github.com/user-attachments/assets/e2d0e6bf-43e7-450c-ba95-09377b069bff" />

<img width="1168" height="346" alt="image" src="https://github.com/user-attachments/assets/5e42633c-448c-43c5-86f5-51c262ac80b3" />
